### PR TITLE
Update Flux bootstrap docs for main

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -23,7 +23,7 @@ If Flux is not already installed on the cluster, bootstrap it against this repos
 flux bootstrap github \
   --owner=mzakhar \
   --repository=vs-book-app \
-  --branch=feature/glassmorphism-themes \
+  --branch=main \
   --path=k8s/flux \
   --private
 ```

--- a/specs/container-deployment-spec.md
+++ b/specs/container-deployment-spec.md
@@ -118,7 +118,7 @@ No code changes should start until this spec is revised against your answers and
 flux bootstrap github \
   --owner=mzakhar \
   --repository=vs-book-app \
-  --branch=feature/glassmorphism-themes \
+  --branch=main \
   --path=k8s/flux \
   --private
 ```


### PR DESCRIPTION
## Summary
- update Flux bootstrap examples to use --branch=main in k8s/README.md and specs/container-deployment-spec.md

## Verification
- cmd /c npm run build
