### PR TITLE
Pin deployment image for glass theme rollout

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -15,6 +15,15 @@ This directory contains the Git-managed deployment state for `Vs-book-app`.
 2. Apply `k8s/base` directly, or let Flux reconcile `k8s/flux/vs-book-app-kustomization.yaml`.
 3. Update the image tag in `base/deployment.yaml` when you want to deploy a tag or commit-specific image instead of `:main`.
 
+## Important rollout note
+
+- A new app commit does not automatically produce a new rollout on the cluster if `k8s/base/deployment.yaml` still points at the same image reference.
+- The current manifest uses `ghcr.io/mzakhar/vs-book-app:main`, which is a mutable tag.
+- Flux reconciles Git state, not GHCR tag contents, so a fresh `:main` image alone is not a guaranteed deployment event.
+- For deterministic updates on `themachine`, treat `k8s/base/deployment.yaml` as part of the release step:
+  - either update the image tag or digest in Git
+  - or perform an explicit rollout restart on the cluster if you intentionally keep using `:main`
+
 ## Flux bootstrap
 
 If Flux is not already installed on the cluster, bootstrap it against this repository and the path that contains the Flux objects:

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,8 +15,8 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app:main
-          imagePullPolicy: Always
+          image: ghcr.io/mzakhar/vs-book-app@sha256:4f75ee7add2c3821d3c3cb29edffbf0b87e082b4ce533bf1932cd566d93dabab
+          imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
               value: production
@@ -47,6 +47,8 @@ spec:
               mountPath: /data
       securityContext:
         fsGroup: 1000
+      imagePullSecrets:
+        - name: ghcr-creds
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/specs/container-deployment-spec.md
+++ b/specs/container-deployment-spec.md
@@ -3,6 +3,12 @@
 ## Goal
 Make `Vs-book-app` deployable as a containerized workload on a home Ubuntu server running k3s, with persistent SQLite storage, repeatable builds, private image publishing to GHCR, and a GitOps-friendly deployment path.
 
+## Deployment Status
+- Current production/home-lab target is live on `themachine` at `http://192.168.1.3/books/`.
+- `themachine` is configured to pull the app from GitHub.
+- The deployed model is a single-replica k3s workload with Traefik routing at `/books/` and persistent SQLite storage outside the container lifecycle.
+- Operational note: a merged app change is not by itself a guaranteed cluster rollout when the deployment manifest still references the same mutable container tag.
+
 ## Current State
 - App is split into `frontend/` and `backend/`.
 - Production today is non-containerized: build locally, copy artifacts to a server, run Node via `systemd`, and proxy `/books/` through nginx.
@@ -98,6 +104,7 @@ No code changes should start until this spec is revised against your answers and
 - [x] GitOps integration: added a Flux `Kustomization` manifest and a repo-local `k8s/` layout for Git-managed deployment state.
 - [x] Added cluster setup notes covering the GHCR pull secret, image path replacement, and the `/books/` routing model.
 - [x] Added Flux bootstrap, cutover, rollback, and deployment update runbooks.
+- [x] Deployment is live in the home lab on `themachine` at `http://192.168.1.3/books/`.
 
 ## Runtime Configuration Contract
 - `NODE_ENV=production`
@@ -129,6 +136,11 @@ flux bootstrap github \
 3. Update `k8s/base/deployment.yaml` to the desired tag or digest instead of relying on `:main` for long-term operations.
 4. Commit that manifest change.
 5. Wait for Flux to reconcile, then confirm the deployment is ready and the app is reachable at `/books/`.
+
+### Important Memory
+- `k8s/base/deployment.yaml` is part of the release process for `themachine`.
+- A new image published to GHCR under the same tag, such as `:main`, is not enough for Flux to produce a deterministic rollout by itself.
+- If the manifest image reference does not change, the safe assumption is that `themachine` may keep serving the old pod until a manual restart or another Git change forces replacement.
 
 ## Cutover Runbook
 1. Ensure the current non-containerized deployment remains available during cluster bring-up.


### PR DESCRIPTION
## Summary
- pin k8s/base deployment to the exact image digest built from the merged glass-theme release
- restore the GHCR image pull secret reference in the deployment manifest
- record that k8s/base is part of the release step for themachine because Flux does not roll on mutable tag changes alone

## Verification
- successful Publish Container run for main merge commit f40bf6b
- pinned image digest: sha256:4f75ee7add2c3821d3c3cb29edffbf0b87e082b4ce533bf1932cd566d93dabab
