### PR TITLE
Add gmail-frontend app to Flux cluster config

### DIFF
--- a/clusters/themachine/apps/gmail-frontend.yaml
+++ b/clusters/themachine/apps/gmail-frontend.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: gmail-frontend
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: https://github.com/mzakhar/gmail-frontend-replacement
+  secretRef:
+    name: gmail-frontend-github
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gmail-frontend
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./deploy/k8s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: gmail-frontend
+  wait: true
+  timeout: 5m

--- a/clusters/themachine/kustomization.yaml
+++ b/clusters/themachine/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - flux-system/gotk-components.yaml
   - flux-system/gotk-sync.yaml
   - apps/vs-book-app.yaml
+  - apps/gmail-frontend.yaml


### PR DESCRIPTION
Adds Flux GitRepository and Kustomization for mzakhar/gmail-frontend-replacement.

Before merging, apply two manual secrets on themachine:

1. GitHub PAT (repo read scope) so Flux can pull the private repo:
```bash
kubectl create secret generic gmail-frontend-github   --namespace flux-system   --from-literal=username=mzakhar   --from-literal=password=<github-pat>
```

2. App secrets — fill deploy/k8s/secret.template.yaml, save as secret.yaml (never commit):
```bash
kubectl apply -f deploy/k8s/secret.yaml
```

3. Add OAuth redirect URI in Google Cloud Console: http://192.168.1.3/gmail/auth/callback

Once merged, Flux reconciles within 10m and deploys to gmail-app namespace.