### PR TITLE
feat: add synth Flux app and cloudflared tunnel deployment

### DIFF
--- a/clusters/themachine/apps/synth.yaml
+++ b/clusters/themachine/apps/synth.yaml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: audio-tools
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: https://github.com/mzakhar/Audio-Tools
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: synth
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./deploy/k8s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: audio-tools
+  wait: true
+  timeout: 5m

--- a/clusters/themachine/cloudflared/deployment.yaml
+++ b/clusters/themachine/cloudflared/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: cloudflared
+  labels:
+    app.kubernetes.io/name: cloudflared
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflared
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cloudflared
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:2025.11.1
+          args:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-tunnel-token
+                  key: token
+          ports:
+            - name: metrics
+              containerPort: 2000
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]

--- a/clusters/themachine/cloudflared/kustomization.yaml
+++ b/clusters/themachine/cloudflared/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml

--- a/clusters/themachine/cloudflared/namespace.yaml
+++ b/clusters/themachine/cloudflared/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflared

--- a/clusters/themachine/cloudflared/setup-tunnel.sh
+++ b/clusters/themachine/cloudflared/setup-tunnel.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Idempotent Cloudflare Tunnel bootstrap for themachine.
+#
+# Creates (or reuses) a remotely-managed tunnel named "themachine", points
+# synth.zakharhome.org at in-cluster Traefik, creates the proxied DNS CNAME,
+# and prints the kubectl command to install the tunnel-token secret.
+#
+# Requires: curl, jq, and CLOUDFLARE_API_TOKEN with scopes:
+#   Account > Cloudflare Tunnel > Edit
+#   Zone    > DNS               > Edit   (zone: zakharhome.org)
+#
+# Usage: CLOUDFLARE_API_TOKEN=... ./setup-tunnel.sh
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN}"
+
+API="https://api.cloudflare.com/client/v4"
+TUNNEL_NAME="themachine"
+ZONE_NAME="zakharhome.org"
+HOSTNAME="synth.${ZONE_NAME}"
+ORIGIN_SERVICE="http://traefik.kube-system.svc.cluster.local:80"
+
+cf() {
+  local method=$1 path=$2 body=${3:-}
+  local args=(-sS -X "$method" "$API$path" \
+    -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    -H "Content-Type: application/json")
+  [ -n "$body" ] && args+=(--data "$body")
+  local resp
+  resp=$(curl "${args[@]}")
+  if [ "$(jq -r '.success' <<<"$resp")" != "true" ]; then
+    echo "Cloudflare API error on $method $path:" >&2
+    jq -r '.errors' <<<"$resp" >&2
+    exit 1
+  fi
+  jq '.result' <<<"$resp"
+}
+
+echo "==> Resolving account and zone"
+ACCOUNT_ID=$(cf GET "/accounts?per_page=5" | jq -r '.[0].id')
+ZONE_ID=$(cf GET "/zones?name=$ZONE_NAME" | jq -r '.[0].id')
+[ "$ZONE_ID" != "null" ] || { echo "zone $ZONE_NAME not found" >&2; exit 1; }
+echo "    account=$ACCOUNT_ID zone=$ZONE_ID"
+
+echo "==> Tunnel: $TUNNEL_NAME"
+TUNNEL_ID=$(cf GET "/accounts/$ACCOUNT_ID/cfd_tunnel?name=$TUNNEL_NAME&is_deleted=false" \
+  | jq -r '.[0].id // empty')
+if [ -z "$TUNNEL_ID" ]; then
+  TUNNEL_ID=$(cf POST "/accounts/$ACCOUNT_ID/cfd_tunnel" \
+    "{\"name\":\"$TUNNEL_NAME\",\"config_src\":\"cloudflare\"}" | jq -r '.id')
+  echo "    created tunnel $TUNNEL_ID"
+else
+  echo "    reusing tunnel $TUNNEL_ID"
+fi
+
+echo "==> Ingress config: $HOSTNAME -> $ORIGIN_SERVICE"
+cf PUT "/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/configurations" "$(jq -n \
+  --arg host "$HOSTNAME" --arg svc "$ORIGIN_SERVICE" '{
+  config: { ingress: [
+    { hostname: $host, service: $svc },
+    { service: "http_status:404" }
+  ]}}')" >/dev/null
+echo "    applied"
+
+echo "==> DNS: $HOSTNAME CNAME ${TUNNEL_ID}.cfargotunnel.com (proxied)"
+RECORD_ID=$(cf GET "/zones/$ZONE_ID/dns_records?type=CNAME&name=$HOSTNAME" \
+  | jq -r '.[0].id // empty')
+DNS_BODY=$(jq -n --arg name "$HOSTNAME" --arg target "${TUNNEL_ID}.cfargotunnel.com" \
+  '{type:"CNAME", name:$name, content:$target, proxied:true, ttl:1}')
+if [ -z "$RECORD_ID" ]; then
+  cf POST "/zones/$ZONE_ID/dns_records" "$DNS_BODY" >/dev/null
+  echo "    created"
+else
+  cf PUT "/zones/$ZONE_ID/dns_records/$RECORD_ID" "$DNS_BODY" >/dev/null
+  echo "    updated"
+fi
+
+echo "==> Tunnel token"
+TOKEN=$(cf GET "/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/token" | jq -r '.')
+
+cat <<EOF
+
+Done. On themachine, install the token secret (cloudflared deployment reads it):
+
+  kubectl create namespace cloudflared --dry-run=client -o yaml | kubectl apply -f -
+  kubectl -n cloudflared create secret generic cloudflared-tunnel-token \\
+    --from-literal=token='$TOKEN' \\
+    --dry-run=client -o yaml | kubectl apply -f -
+
+Then let Flux reconcile (or: flux reconcile kustomization flux-system --with-source)
+and verify: https://$HOSTNAME
+EOF

--- a/clusters/themachine/cloudflared/setup-tunnel.sh
+++ b/clusters/themachine/cloudflared/setup-tunnel.sh
@@ -37,9 +37,11 @@ cf() {
 }
 
 echo "==> Resolving account and zone"
-ACCOUNT_ID=$(cf GET "/accounts?per_page=5" | jq -r '.[0].id')
-ZONE_ID=$(cf GET "/zones?name=$ZONE_NAME" | jq -r '.[0].id')
-[ "$ZONE_ID" != "null" ] || { echo "zone $ZONE_NAME not found" >&2; exit 1; }
+ZONE=$(cf GET "/zones?name=$ZONE_NAME")
+ZONE_ID=$(jq -r '.[0].id // empty' <<<"$ZONE")
+ACCOUNT_ID=$(jq -r '.[0].account.id // empty' <<<"$ZONE")
+[ -n "$ZONE_ID" ] || { echo "zone $ZONE_NAME not found" >&2; exit 1; }
+[ -n "$ACCOUNT_ID" ] || { echo "could not resolve account id from zone" >&2; exit 1; }
 echo "    account=$ACCOUNT_ID zone=$ZONE_ID"
 
 echo "==> Tunnel: $TUNNEL_NAME"

--- a/clusters/themachine/kustomization.yaml
+++ b/clusters/themachine/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - flux-system/gotk-sync.yaml
   - apps/vs-book-app.yaml
   - apps/gmail-frontend.yaml
+  - apps/synth.yaml
+  - cloudflared


### PR DESCRIPTION
## Summary
- Flux `GitRepository` + `Kustomization` for `mzakhar/Audio-Tools` (`deploy/k8s`), wiring the synth app into the cluster's GitOps reconciliation.
- cloudflared `Deployment` (2 replicas), reading its tunnel token from a manually-applied secret `cloudflared-tunnel-token`.
- Idempotent Cloudflare API bootstrap script (`setup-tunnel.sh`) for tunnel + DNS creation.

Tunnel token secret is applied manually on themachine (same pattern as `gmail-app-secrets`); `setup-tunnel.sh` prints the kubectl command.

## Test plan
- [ ] Flux reconciles `synth` app and pulls manifests from `Audio-Tools` `deploy/k8s`
- [ ] cloudflared pods come up healthy once `cloudflared-tunnel-token` secret is applied
- [ ] `setup-tunnel.sh` creates tunnel + DNS record idempotently on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)