### PR TITLE
feat: user accounts — admin-created users, session auth, per-user libraries

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,12 +8,17 @@
       "name": "vs-book-app-backend",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.5.2",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.5",
@@ -135,6 +140,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -154,6 +166,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -473,6 +495,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -745,6 +776,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -1037,6 +1087,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1540,11 +1608,10 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,12 +7,17 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.5.2",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.5",

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -2,6 +2,7 @@ import { open, Database } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import fs from 'fs/promises';
 import path from 'path';
+import bcrypt from 'bcryptjs';
 
 let _db: Database | null = null;
 
@@ -56,6 +57,22 @@ export async function getDb(): Promise<Database> {
       genre      TEXT NOT NULL,
       PRIMARY KEY (book_id, genre)
     );
+
+    CREATE TABLE IF NOT EXISTS users (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      username      TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      role          TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('admin', 'user')),
+      is_active     INTEGER NOT NULL DEFAULT 1,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      token_hash TEXT PRIMARY KEY,
+      user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
   `);
 
   // 2. Run migrations for columns
@@ -64,6 +81,8 @@ export async function getDb(): Promise<Database> {
     `ALTER TABLE books ADD COLUMN series_position REAL`,
     `ALTER TABLE books ADD COLUMN page_count      INTEGER`,
     `ALTER TABLE books ADD COLUMN description     TEXT`,
+    `ALTER TABLE books  ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE`,
+    `ALTER TABLE series ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE`,
   ];
   for (const sql of migrations) {
     try { await _db.run(sql); } catch { /* column already exists */ }
@@ -85,6 +104,70 @@ export async function getDb(): Promise<Database> {
     }
   } catch (e) {
     console.error("Genre migration failed:", e);
+  }
+
+  // 4. Rebuild series table with a composite UNIQUE(user_id, name) constraint (once).
+  // Sentinel: does a UNIQUE index exist on `name` alone (old schema)? If so, rebuild.
+  const seriesIndexes: any[] = await _db.all(`PRAGMA index_list('series')`);
+  let needsRebuild = false;
+  for (const idx of seriesIndexes) {
+    if (!idx.unique) continue;
+    const cols: any[] = await _db.all(`PRAGMA index_info('${idx.name}')`);
+    const colNames = cols.map((c: any) => c.name);
+    if (colNames.length === 1 && colNames[0] === 'name') {
+      needsRebuild = true;
+    }
+  }
+  if (needsRebuild) {
+    await _db.exec('PRAGMA foreign_keys = OFF');
+    try {
+      await _db.exec('BEGIN TRANSACTION');
+      await _db.exec(`
+        CREATE TABLE series_new (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          name        TEXT NOT NULL,
+          total_books INTEGER,
+          created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+          user_id     INTEGER REFERENCES users(id) ON DELETE CASCADE,
+          UNIQUE(user_id, name)
+        );
+      `);
+      await _db.exec(`
+        INSERT INTO series_new (id, name, total_books, created_at, user_id)
+        SELECT id, name, total_books, created_at, user_id FROM series;
+      `);
+      await _db.exec('DROP TABLE series');
+      await _db.exec('ALTER TABLE series_new RENAME TO series');
+      await _db.exec('COMMIT');
+    } catch (e) {
+      await _db.exec('ROLLBACK');
+      throw e;
+    } finally {
+      await _db.exec('PRAGMA foreign_keys = ON');
+    }
+  }
+
+  // 5. Seed admin user if none exist
+  const userCount: any = await _db.get('SELECT COUNT(*) as c FROM users');
+  if (userCount && userCount.c === 0) {
+    const adminUsername = process.env.ADMIN_USERNAME;
+    const adminPassword = process.env.ADMIN_PASSWORD;
+    if (adminUsername && adminPassword) {
+      const hash = await bcrypt.hash(adminPassword, 12);
+      await _db.run(
+        `INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'admin')`,
+        adminUsername, hash
+      );
+    } else {
+      console.warn('no users exist and ADMIN_USERNAME/ADMIN_PASSWORD not set — nobody can log in');
+    }
+  }
+
+  // 6. Backfill ownership of pre-existing books/series to the first admin
+  const admin: any = await _db.get(`SELECT id FROM users WHERE role = 'admin' ORDER BY id ASC LIMIT 1`);
+  if (admin) {
+    await _db.run(`UPDATE books SET user_id = ? WHERE user_id IS NULL`, admin.id);
+    await _db.run(`UPDATE series SET user_id = ? WHERE user_id IS NULL`, admin.id);
   }
 
   return _db;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,24 +1,43 @@
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import path from 'path';
+import cookieParser from 'cookie-parser';
+import rateLimit from 'express-rate-limit';
 import booksRouter from './routes/books';
 import notesRouter from './routes/notes';
 import seriesRouter from './routes/series';
+import authRouter from './routes/auth';
+import usersRouter from './routes/users';
 import { getDb } from './database';
+import { requireAuth, requireAdmin } from './middleware/auth';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 const IS_PROD = process.env.NODE_ENV === 'production';
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../../books.db');
 
+// Two trusted hops in production: Cloudflare edge -> Traefik ingress. A blanket
+// `true` would let clients spoof X-Forwarded-For and dodge the login rate limit.
+app.set('trust proxy', IS_PROD ? 2 : false);
+
 if (!IS_PROD) {
   app.use(cors({ origin: ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:5175'] }));
 }
 app.use(express.json());
+app.use(cookieParser());
 
-app.use('/api/books', booksRouter);
-app.use('/api/notes', notesRouter);
-app.use('/api/series', seriesRouter);
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+});
+
+app.use('/api/auth/login', loginLimiter);
+app.use('/api/auth', authRouter);
+app.use('/api/users', requireAuth, requireAdmin, usersRouter);
+app.use('/api/books', requireAuth, booksRouter);
+app.use('/api/notes', requireAuth, notesRouter);
+app.use('/api/series', requireAuth, seriesRouter);
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
 if (IS_PROD) {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,103 @@
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+import { Database } from 'sqlite';
+import { getDb } from '../database';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: { id: number; username: string; role: 'admin' | 'user' };
+    }
+  }
+}
+
+export const SESSION_COOKIE = 'book_app_session';
+const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const RENEWAL_THRESHOLD_MS = 15 * 24 * 60 * 60 * 1000; // 15 days
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function cookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: SESSION_MAX_AGE_MS,
+    path: '/',
+  };
+}
+
+export async function createSession(db: Database, userId: number, res: Response): Promise<void> {
+  const token = crypto.randomBytes(32).toString('hex');
+  const tokenHash = hashToken(token);
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_MS).toISOString();
+
+  await db.run(
+    `INSERT INTO sessions (token_hash, user_id, expires_at) VALUES (?, ?, ?)`,
+    tokenHash, userId, expiresAt
+  );
+
+  res.cookie(SESSION_COOKIE, token, cookieOptions());
+}
+
+export async function destroySession(db: Database, req: Request, res: Response): Promise<void> {
+  const token = req.cookies?.[SESSION_COOKIE];
+  if (token) {
+    await db.run(`DELETE FROM sessions WHERE token_hash = ?`, hashToken(token));
+  }
+  res.clearCookie(SESSION_COOKIE, { path: '/' });
+}
+
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const token = req.cookies?.[SESSION_COOKIE];
+  if (!token) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+
+  const db = await getDb();
+  const tokenHash = hashToken(token);
+
+  const row: any = await db.get(
+    `SELECT s.token_hash, s.expires_at, u.id as user_id, u.username, u.role, u.is_active
+     FROM sessions s JOIN users u ON u.id = s.user_id
+     WHERE s.token_hash = ?`,
+    tokenHash
+  );
+
+  if (!row || !row.is_active) {
+    if (row) await db.run(`DELETE FROM sessions WHERE token_hash = ?`, tokenHash);
+    res.clearCookie(SESSION_COOKIE, { path: '/' });
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+
+  const expiresAt = new Date(row.expires_at).getTime();
+  if (expiresAt < Date.now()) {
+    await db.run(`DELETE FROM sessions WHERE token_hash = ?`, tokenHash);
+    res.clearCookie(SESSION_COOKIE, { path: '/' });
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+
+  req.user = { id: row.user_id, username: row.username, role: row.role };
+
+  // Sliding renewal: extend if within 15 days of expiry
+  if (expiresAt - Date.now() < RENEWAL_THRESHOLD_MS) {
+    const newExpiresAt = new Date(Date.now() + SESSION_MAX_AGE_MS).toISOString();
+    await db.run(`UPDATE sessions SET expires_at = ? WHERE token_hash = ?`, newExpiresAt, tokenHash);
+    res.cookie(SESSION_COOKIE, token, cookieOptions());
+  }
+
+  next();
+}
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  if (req.user?.role !== 'admin') {
+    res.status(403).json({ error: 'forbidden' });
+    return;
+  }
+  next();
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import { getDb } from '../database';
+import { asyncHandler } from '../asyncHandler';
+import { createSession, destroySession, requireAuth } from '../middleware/auth';
+
+const router = Router();
+
+// Fixed dummy hash so login timing is uniform whether or not the username exists.
+const DUMMY_HASH = '$2a$12$C6UzMDM.H6dfI/f/IKcEeOa8i1V6dGmuVs.dRnO2XM.pP3Bq2mkci';
+
+router.post('/login', asyncHandler(async (req: Request, res: Response) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(401).json({ error: 'Invalid username or password' });
+  }
+
+  const db = await getDb();
+  const user: any = await db.get(
+    `SELECT * FROM users WHERE username = ? AND is_active = 1`,
+    username
+  );
+
+  const hashToCompare = user ? user.password_hash : DUMMY_HASH;
+  const valid = await bcrypt.compare(password, hashToCompare);
+
+  if (!user || !valid) {
+    return res.status(401).json({ error: 'Invalid username or password' });
+  }
+
+  await createSession(db, user.id, res);
+  res.json({ id: user.id, username: user.username, role: user.role });
+}));
+
+router.post('/logout', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  await destroySession(db, req, res);
+  res.status(204).end();
+}));
+
+router.get('/me', requireAuth, asyncHandler(async (req: Request, res: Response) => {
+  res.json({ id: req.user!.id, username: req.user!.username, role: req.user!.role });
+}));
+
+export default router;

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -18,10 +18,11 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
   const q = req.query.q as string | undefined;
   const status = req.query.status as string | undefined;
-  
+
   let query = SELECT_BOOK;
   const params: any[] = [];
-  const where: string[] = [];
+  const where: string[] = [`b.user_id = ?`];
+  params.push(req.user!.id);
 
   if (q && q.trim()) {
     const like = `%${q.trim()}%`;
@@ -37,9 +38,7 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
     where.push(`b.status != 'wishlist'`);
   }
 
-  if (where.length > 0) {
-    query += ` WHERE ` + where.join(' AND ');
-  }
+  query += ` WHERE ` + where.join(' AND ');
 
   query += ` ${GROUP_BY_BOOK} ORDER BY b.created_at DESC`;
   res.json(await db.all(query, ...params));
@@ -54,12 +53,12 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
 
   let series_id: number | null = null;
   if (series_name && series_name.trim()) {
-    series_id = await findOrCreateSeries(db, series_name.trim());
+    series_id = await findOrCreateSeries(db, series_name.trim(), req.user!.id);
   }
 
   const result = await db.run(
-    `INSERT INTO books (title, author, status, rating, cover_url, series_id, series_position, page_count, description)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO books (title, author, status, rating, cover_url, series_id, series_position, page_count, description, user_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     title.trim(),
     author?.trim() || null,
     status || 'unread',
@@ -68,7 +67,8 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
     series_id,
     series_position != null ? Number(series_position) : null,
     page_count ? Number(page_count) : null,
-    description?.trim() || null
+    description?.trim() || null,
+    req.user!.id
   );
 
   const bookId = result.lastID;
@@ -79,12 +79,13 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
     }
   }
 
-  res.status(201).json(await db.get(`${SELECT_BOOK} WHERE b.id = ? ${GROUP_BY_BOOK}`, bookId));
+  res.status(201).json(await db.get(`${SELECT_BOOK} WHERE b.id = ? AND b.user_id = ? ${GROUP_BY_BOOK}`, bookId, req.user!.id));
 }));
 
-router.get('/stats', asyncHandler(async (_req: Request, res: Response) => {
+router.get('/stats', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  
+  const userId = req.user!.id;
+
   const counters = await db.get(`
     SELECT
       COUNT(*) as total_books,
@@ -93,21 +94,26 @@ router.get('/stats', asyncHandler(async (_req: Request, res: Response) => {
       SUM(CASE WHEN status='read'    THEN 1 ELSE 0 END) as read,
       ROUND(AVG(CASE WHEN rating IS NOT NULL THEN rating END), 1) as avg_rating
     FROM books
-  `);
-  
-  const notesCount = await db.get(`SELECT COUNT(*) as count FROM notes`);
-  
+    WHERE user_id = ?
+  `, userId);
+
+  const notesCount = await db.get(`
+    SELECT COUNT(*) as count FROM notes n JOIN books b ON b.id = n.book_id WHERE b.user_id = ?
+  `, userId);
+
   const byGenre = await db.all(`
-    SELECT genre, COUNT(*) as count
-    FROM book_genres GROUP BY genre ORDER BY count DESC LIMIT 10
-  `);
-  
+    SELECT bg.genre as genre, COUNT(*) as count
+    FROM book_genres bg JOIN books b ON b.id = bg.book_id
+    WHERE b.user_id = ?
+    GROUP BY bg.genre ORDER BY count DESC LIMIT 10
+  `, userId);
+
   const byRating = await db.all(`
     SELECT rating, COUNT(*) as count FROM books
-    WHERE rating IS NOT NULL GROUP BY rating ORDER BY rating
-  `);
-  
-  const recent = await db.all(`${SELECT_BOOK} ${GROUP_BY_BOOK} ORDER BY b.created_at DESC LIMIT 5`);
+    WHERE rating IS NOT NULL AND user_id = ? GROUP BY rating ORDER BY rating
+  `, userId);
+
+  const recent = await db.all(`${SELECT_BOOK} WHERE b.user_id = ? ${GROUP_BY_BOOK} ORDER BY b.created_at DESC LIMIT 5`, userId);
 
   res.json({
     total_books: counters.total_books ?? 0,
@@ -124,14 +130,14 @@ router.get('/stats', asyncHandler(async (_req: Request, res: Response) => {
 
 router.get('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const book = await db.get(`${SELECT_BOOK} WHERE b.id = ? ${GROUP_BY_BOOK}`, req.params.id);
+  const book = await db.get(`${SELECT_BOOK} WHERE b.id = ? AND b.user_id = ? ${GROUP_BY_BOOK}`, req.params.id, req.user!.id);
   if (!book) return res.status(404).json({ error: 'Book not found' });
   res.json(book);
 }));
 
 router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const existing = await db.get(`SELECT * FROM books WHERE id = ?`, req.params.id);
+  const existing = await db.get(`SELECT * FROM books WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   if (!existing) return res.status(404).json({ error: 'Book not found' });
 
   const { title, author, genre, genres, status, rating, cover_url,
@@ -142,13 +148,13 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
     if (series_name === '' || series_name === null) {
       series_id = null;
     } else {
-      series_id = await findOrCreateSeries(db, series_name.trim());
+      series_id = await findOrCreateSeries(db, series_name.trim(), req.user!.id);
     }
   }
 
   await db.run(
     `UPDATE books SET title=?, author=?, status=?, rating=?, cover_url=?,
-     series_id=?, series_position=?, page_count=?, description=? WHERE id=?`,
+     series_id=?, series_position=?, page_count=?, description=? WHERE id=? AND user_id=?`,
     title !== undefined ? title.trim() || existing.title : existing.title,
     author !== undefined ? author?.trim() || null : existing.author,
     status !== undefined ? status : existing.status,
@@ -158,7 +164,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
     series_position !== undefined ? (series_position != null ? Number(series_position) : null) : existing.series_position,
     page_count !== undefined ? (page_count ? Number(page_count) : null) : existing.page_count,
     description !== undefined ? description?.trim() || null : existing.description,
-    req.params.id
+    req.params.id, req.user!.id
   );
 
   if (genres !== undefined || genre !== undefined) {
@@ -171,14 +177,14 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
     }
   }
 
-  res.json(await db.get(`${SELECT_BOOK} WHERE b.id = ? ${GROUP_BY_BOOK}`, req.params.id));
+  res.json(await db.get(`${SELECT_BOOK} WHERE b.id = ? AND b.user_id = ? ${GROUP_BY_BOOK}`, req.params.id, req.user!.id));
 }));
 
 router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const existing = await db.get(`SELECT id FROM books WHERE id = ?`, req.params.id);
+  const existing = await db.get(`SELECT id FROM books WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   if (!existing) return res.status(404).json({ error: 'Book not found' });
-  await db.run(`DELETE FROM books WHERE id = ?`, req.params.id);
+  await db.run(`DELETE FROM books WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   res.status(204).end();
 }));
 

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -6,6 +6,9 @@ const router = Router();
 
 router.get('/:bookId', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
+  const book = await db.get(`SELECT id FROM books WHERE id = ? AND user_id = ?`, req.params.bookId, req.user!.id);
+  if (!book) return res.status(404).json({ error: 'Book not found' });
+
   res.json(await db.all(
     `SELECT * FROM notes WHERE book_id = ? ORDER BY created_at DESC`,
     req.params.bookId
@@ -17,7 +20,7 @@ router.post('/:bookId', asyncHandler(async (req: Request, res: Response) => {
   if (!content || !content.trim()) return res.status(400).json({ error: 'Content is required' });
 
   const db = await getDb();
-  const book = await db.get(`SELECT id FROM books WHERE id = ?`, req.params.bookId);
+  const book = await db.get(`SELECT id FROM books WHERE id = ? AND user_id = ?`, req.params.bookId, req.user!.id);
   if (!book) return res.status(404).json({ error: 'Book not found' });
 
   const result = await db.run(
@@ -32,7 +35,10 @@ router.put('/:noteId', asyncHandler(async (req: Request, res: Response) => {
   if (!content || !content.trim()) return res.status(400).json({ error: 'Content is required' });
 
   const db = await getDb();
-  const existing = await db.get(`SELECT id FROM notes WHERE id = ?`, req.params.noteId);
+  const existing = await db.get(
+    `SELECT n.id FROM notes n JOIN books b ON b.id = n.book_id WHERE n.id = ? AND b.user_id = ?`,
+    req.params.noteId, req.user!.id
+  );
   if (!existing) return res.status(404).json({ error: 'Note not found' });
 
   await db.run(
@@ -44,7 +50,10 @@ router.put('/:noteId', asyncHandler(async (req: Request, res: Response) => {
 
 router.delete('/:noteId', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const existing = await db.get(`SELECT id FROM notes WHERE id = ?`, req.params.noteId);
+  const existing = await db.get(
+    `SELECT n.id FROM notes n JOIN books b ON b.id = n.book_id WHERE n.id = ? AND b.user_id = ?`,
+    req.params.noteId, req.user!.id
+  );
   if (!existing) return res.status(404).json({ error: 'Note not found' });
   await db.run(`DELETE FROM notes WHERE id = ?`, req.params.noteId);
   res.status(204).end();

--- a/backend/src/routes/series.ts
+++ b/backend/src/routes/series.ts
@@ -5,44 +5,44 @@ import { asyncHandler } from '../asyncHandler';
 
 const router = Router();
 
-export async function findOrCreateSeries(db: Database, name: string): Promise<number> {
+export async function findOrCreateSeries(db: Database, name: string, userId: number): Promise<number> {
   const existing = await db.get(
-    `SELECT id FROM series WHERE name = ? COLLATE NOCASE`,
-    name.trim()
+    `SELECT id FROM series WHERE name = ? COLLATE NOCASE AND user_id = ?`,
+    name.trim(), userId
   );
   if (existing) return existing.id;
   try {
-    const result = await db.run(`INSERT INTO series (name) VALUES (?)`, name.trim());
+    const result = await db.run(`INSERT INTO series (name, user_id) VALUES (?, ?)`, name.trim(), userId);
     return result.lastID!;
   } catch {
     // UNIQUE race — fetch it
-    const row = await db.get(`SELECT id FROM series WHERE name = ? COLLATE NOCASE`, name.trim());
+    const row = await db.get(`SELECT id FROM series WHERE name = ? COLLATE NOCASE AND user_id = ?`, name.trim(), userId);
     return row.id;
   }
 }
 
-async function seriesWithBooks(db: Database, id: number) {
-  const series = await db.get(`SELECT * FROM series WHERE id = ?`, id);
+async function seriesWithBooks(db: Database, id: number, userId: number) {
+  const series = await db.get(`SELECT * FROM series WHERE id = ? AND user_id = ?`, id, userId);
   if (!series) return null;
   const books = await db.all(
     `SELECT id, title, author, status, series_position, cover_url, rating
-     FROM books WHERE series_id = ? ORDER BY series_position ASC NULLS LAST, id ASC`,
-    id
+     FROM books WHERE series_id = ? AND user_id = ? ORDER BY series_position ASC NULLS LAST, id ASC`,
+    id, userId
   );
   const read_count = books.filter((b: any) => b.status === 'read').length;
   return { ...series, books, book_count: books.length, read_count };
 }
 
-router.get('/', asyncHandler(async (_req: Request, res: Response) => {
+router.get('/', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const all = await db.all(`SELECT * FROM series ORDER BY name ASC`);
-  const result = await Promise.all(all.map((s: any) => seriesWithBooks(db, s.id)));
+  const all = await db.all(`SELECT * FROM series WHERE user_id = ? ORDER BY name ASC`, req.user!.id);
+  const result = await Promise.all(all.map((s: any) => seriesWithBooks(db, s.id, req.user!.id)));
   res.json(result);
 }));
 
 router.get('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const s = await seriesWithBooks(db, Number(req.params.id));
+  const s = await seriesWithBooks(db, Number(req.params.id), req.user!.id);
   if (!s) return res.status(404).json({ error: 'Series not found' });
   res.json(s);
 }));
@@ -53,10 +53,10 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
   try {
     const result = await db.run(
-      `INSERT INTO series (name, total_books) VALUES (?, ?)`,
-      name.trim(), total_books ? Number(total_books) : null
+      `INSERT INTO series (name, total_books, user_id) VALUES (?, ?, ?)`,
+      name.trim(), total_books ? Number(total_books) : null, req.user!.id
     );
-    const s = await seriesWithBooks(db, result.lastID!);
+    const s = await seriesWithBooks(db, result.lastID!, req.user!.id);
     res.status(201).json(s);
   } catch {
     res.status(409).json({ error: 'Series name already exists' });
@@ -65,23 +65,23 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
 
 router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const existing = await db.get(`SELECT * FROM series WHERE id = ?`, req.params.id);
+  const existing = await db.get(`SELECT * FROM series WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   if (!existing) return res.status(404).json({ error: 'Series not found' });
   const { name, total_books } = req.body;
   await db.run(
-    `UPDATE series SET name=?, total_books=? WHERE id=?`,
+    `UPDATE series SET name=?, total_books=? WHERE id=? AND user_id=?`,
     name !== undefined ? name.trim() || existing.name : existing.name,
     total_books !== undefined ? (total_books ? Number(total_books) : null) : existing.total_books,
-    req.params.id
+    req.params.id, req.user!.id
   );
-  res.json(await seriesWithBooks(db, Number(req.params.id)));
+  res.json(await seriesWithBooks(db, Number(req.params.id), req.user!.id));
 }));
 
 router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
-  const existing = await db.get(`SELECT id FROM series WHERE id = ?`, req.params.id);
+  const existing = await db.get(`SELECT id FROM series WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   if (!existing) return res.status(404).json({ error: 'Series not found' });
-  await db.run(`DELETE FROM series WHERE id = ?`, req.params.id);
+  await db.run(`DELETE FROM series WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
   res.status(204).end();
 }));
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,88 @@
+import { Router, Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import { getDb } from '../database';
+import { asyncHandler } from '../asyncHandler';
+
+const router = Router();
+
+router.get('/', asyncHandler(async (_req: Request, res: Response) => {
+  const db = await getDb();
+  const users = await db.all(
+    `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
+  );
+  res.json(users);
+}));
+
+router.post('/', asyncHandler(async (req: Request, res: Response) => {
+  const { username, password, role } = req.body;
+  if (!username || !username.trim()) return res.status(400).json({ error: 'Username is required' });
+  if (!password || password.length < 8) return res.status(400).json({ error: 'Password must be at least 8 characters' });
+  const roleToUse = role === 'admin' ? 'admin' : 'user';
+
+  const db = await getDb();
+  const existing = await db.get(`SELECT id FROM users WHERE username = ?`, username.trim());
+  if (existing) return res.status(409).json({ error: 'Username already exists' });
+
+  const hash = await bcrypt.hash(password, 12);
+  const result = await db.run(
+    `INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)`,
+    username.trim(), hash, roleToUse
+  );
+
+  const user = await db.get(
+    `SELECT id, username, role, is_active, created_at FROM users WHERE id = ?`,
+    result.lastID
+  );
+  res.status(201).json(user);
+}));
+
+router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  const existing = await db.get(`SELECT * FROM users WHERE id = ?`, req.params.id);
+  if (!existing) return res.status(404).json({ error: 'User not found' });
+
+  const { password, is_active, role } = req.body;
+
+  // Lockout guard: an admin cannot deactivate or demote their own account.
+  const isSelf = Number(req.params.id) === req.user!.id;
+  if (isSelf && (is_active !== undefined || role !== undefined)) {
+    return res.status(400).json({ error: 'Cannot change your own active status or role' });
+  }
+
+  if (password !== undefined) {
+    if (!password || password.length < 8) return res.status(400).json({ error: 'Password must be at least 8 characters' });
+    const hash = await bcrypt.hash(password, 12);
+    await db.run(`UPDATE users SET password_hash = ? WHERE id = ?`, hash, req.params.id);
+    await db.run(`DELETE FROM sessions WHERE user_id = ?`, req.params.id);
+  }
+
+  if (is_active !== undefined) {
+    await db.run(`UPDATE users SET is_active = ? WHERE id = ?`, is_active ? 1 : 0, req.params.id);
+  }
+
+  if (role !== undefined) {
+    if (role !== 'admin' && role !== 'user') return res.status(400).json({ error: 'Invalid role' });
+    await db.run(`UPDATE users SET role = ? WHERE id = ?`, role, req.params.id);
+  }
+
+  const user = await db.get(
+    `SELECT id, username, role, is_active, created_at FROM users WHERE id = ?`,
+    req.params.id
+  );
+  res.json(user);
+}));
+
+router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
+  if (Number(req.params.id) === req.user!.id) {
+    return res.status(400).json({ error: 'Cannot delete your own account' });
+  }
+
+  const db = await getDb();
+  const existing = await db.get(`SELECT id FROM users WHERE id = ?`, req.params.id);
+  if (!existing) return res.status(404).json({ error: 'User not found' });
+
+  await db.run(`DELETE FROM users WHERE id = ?`, req.params.id);
+  res.status(204).end();
+}));
+
+export default router;

--- a/docs/plans/2026-07-11-user-accounts-design.md
+++ b/docs/plans/2026-07-11-user-accounts-design.md
@@ -1,0 +1,93 @@
+# User Accounts Design
+
+Date: 2026-07-11
+Status: approved
+
+## Goal
+
+Multi-user support: each user has their own book library, series, and notes. Users are created by an admin (no self-registration). Secure sign-in required before the app is published to the wider internet (Cloudflare → homelab Traefik → service).
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Data model | Fully separate libraries per user (`user_id` ownership on books and series; notes inherit via book cascade) |
+| Auth | Server-side sessions, httpOnly cookies; bcryptjs password hashes |
+| User creation | Admin page in app; first admin seeded from env vars |
+| Existing data | Backfilled to the first (seeded) admin user |
+
+## Schema
+
+New tables:
+
+```sql
+CREATE TABLE users (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  username      TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  role          TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('admin', 'user')),
+  is_active     INTEGER NOT NULL DEFAULT 1,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE sessions (
+  token_hash TEXT PRIMARY KEY,          -- SHA-256 of the raw cookie token
+  user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+Ownership columns via the existing migrations-array pattern (`backend/src/database.ts`):
+
+```sql
+ALTER TABLE books  ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE series ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE;
+```
+
+Structural migration (the only table rebuild): `series.name` is globally UNIQUE today; it must become UNIQUE per `(user_id, name)`. SQLite cannot alter constraints, so: create `series_new` with the composite unique constraint, copy rows, drop `series`, rename. Guard so it runs once (check via `PRAGMA index_list` / sentinel).
+
+Startup order: create tables → run migrations → seed admin if `users` is empty (from `ADMIN_USERNAME` / `ADMIN_PASSWORD` env) → backfill `UPDATE books/series SET user_id = <admin id> WHERE user_id IS NULL`.
+
+## Auth mechanics
+
+- Passwords: bcryptjs (pure JS — no native build in `node:20-bookworm-slim`), cost 12.
+- Login: verify password → generate 32 random bytes (`crypto.randomBytes`), store SHA-256 hex in `sessions`, set raw token as cookie `book_app_session`: `httpOnly`, `SameSite=Lax`, `Secure` when `NODE_ENV=production`, `maxAge` 30 days. Sliding renewal: extend `expires_at` when a request arrives past half-life.
+- Logout: delete session row, clear cookie.
+- Rate limit `POST /api/auth/login` with `express-rate-limit` (e.g. 10/15min per IP). Requires `app.set('trust proxy', true)` so the limiter keys on the real client IP behind Cloudflare/Traefik.
+- Inactive users (`is_active = 0`): login refused, existing sessions rejected.
+- Expired sessions purged opportunistically on lookup.
+
+## Backend routes
+
+- `backend/src/middleware/auth.ts` — `requireAuth` (cookie → session lookup → attach `req.user`, 401 otherwise), `requireAdmin` (403 unless `role === 'admin'`).
+- `backend/src/routes/auth.ts` — `POST /api/auth/login`, `POST /api/auth/logout`, `GET /api/auth/me`.
+- `backend/src/routes/users.ts` (admin only) — `GET /api/users`, `POST /api/users` (username, password, role), `PUT /api/users/:id` (reset password, toggle active, role), `DELETE /api/users/:id` (refuse self-delete; cascade wipes their library).
+- Existing `books.ts`, `notes.ts`, `series.ts`: mounted behind `requireAuth`; every query scoped by `req.user.id` (notes scope via join to `books.user_id`). Cross-user IDs return 404, not 403.
+- `/api/health` stays public (k8s probes).
+
+New deps: `bcryptjs`, `cookie-parser`, `express-rate-limit` (+ types).
+
+## Frontend
+
+- `AuthContext` — `GET /api/auth/me` on mount; `user | null | loading`. Provides `login`, `logout`.
+- `LoginPage` at `/login`, outside `Layout`.
+- Route guard: unauthenticated → redirect `/login`. Axios response interceptor: 401 → clear context → `/login` (skip for the `/auth/me` probe itself).
+- `UsersPage` at `/users` — nav link rendered only for `role === 'admin'`; create user, reset password, activate/deactivate.
+- Logout button + current username in `Layout` sidebar.
+- Theme preference stays device-local (`book_app_theme`), unchanged.
+
+## Deployment notes / handoff to infra agent
+
+- `ADMIN_USERNAME` / `ADMIN_PASSWORD` as a k8s Secret referenced in `k8s/base/deployment.yaml`. Seed only runs when `users` is empty — rotating the env var later does NOT change the password (use the admin UI).
+- Cloudflare terminates TLS; `Secure` cookie works from day one.
+- **Handoff item:** restrict origin so only Cloudflare IPs reach Traefik for this host, otherwise the app is reachable plain-HTTP around Cloudflare.
+- CSRF: state-changing endpoints are non-GET, CORS is locked to dev origins, cookie is `SameSite=Lax` — adequate for this API shape.
+
+## Build phases
+
+1. Backend: schema, migrations, seed, auth middleware, auth/users routes, scoping of existing routes.
+2. Frontend: AuthContext, LoginPage, route guard, interceptor, UsersPage, Layout changes.
+3. k8s: Secret wiring in deployment manifest (coordinate with infra agent).
+
+Phases implemented by `cavecrew-implementer` agents from written briefs; main session orchestrates, verifies, and commits.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,50 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { ReactNode } from 'react';
 import { ToastProvider } from './components/Toast';
+import { AuthProvider, useAuth } from './context/AuthContext';
 import Layout from './components/Layout';
+import LoginPage from './pages/LoginPage';
 import Dashboard from './pages/Dashboard';
 import BookList from './pages/BookList';
 import BookDetail from './pages/BookDetail';
 import SeriesPage from './pages/SeriesPage';
 import Wishlist from './pages/Wishlist';
+import UsersPage from './pages/UsersPage';
+
+function RequireAuth({ children }: { children: ReactNode }) {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) return <div className="auth-page"><p>Loading…</p></div>;
+  if (!user) return <Navigate to="/login" replace state={{ from: location }} />;
+  return <>{children}</>;
+}
 
 export default function App() {
   return (
     <BrowserRouter basename="/books">
       <ToastProvider>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<Dashboard />} />
-            <Route path="library" element={<BookList />} />
-            <Route path="wishlist" element={<Wishlist />} />
-            <Route path="books/:id" element={<BookDetail />} />
-            <Route path="series" element={<SeriesPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Route>
-        </Routes>
+        <AuthProvider>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <Layout />
+                </RequireAuth>
+              }
+            >
+              <Route index element={<Dashboard />} />
+              <Route path="library" element={<BookList />} />
+              <Route path="wishlist" element={<Wishlist />} />
+              <Route path="books/:id" element={<BookDetail />} />
+              <Route path="series" element={<SeriesPage />} />
+              <Route path="users" element={<UsersPage />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Route>
+          </Routes>
+        </AuthProvider>
       </ToastProvider>
     </BrowserRouter>
   );

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,48 @@
 import axios from 'axios';
-import type { Book, BookStats, Note, Series } from '../types';
+import type { AuthUser, Book, BookStats, ManagedUser, Note, Series, UserRole } from '../types';
 
 const api = axios.create({ baseURL: import.meta.env.VITE_API_BASE || '/api' });
+
+// 401 handling: AuthContext registers a callback on mount so this module
+// never has to import context code (would create a circular import).
+let onUnauthorized: (() => void) | null = null;
+export const registerUnauthorizedHandler = (cb: (() => void) | null) => {
+  onUnauthorized = cb;
+};
+// Guards against React 18 Strict Mode double-mount: unregister only clears
+// the handler it registered, so a stale cleanup can't clobber a newer one.
+export const unregisterUnauthorizedHandler = (cb: () => void) => {
+  if (onUnauthorized === cb) onUnauthorized = null;
+};
+
+api.interceptors.response.use(
+  r => r,
+  err => {
+    const url: string = err?.config?.url || '';
+    if (err?.response?.status === 401 && !url.startsWith('/auth/')) {
+      onUnauthorized?.();
+    }
+    return Promise.reject(err);
+  }
+);
+
+// Auth
+export const login = (username: string, password: string) =>
+  api.post<AuthUser>('/auth/login', { username, password }).then(r => r.data);
+export const logout = () =>
+  api.post('/auth/logout');
+export const getMe = () =>
+  api.get<AuthUser>('/auth/me').then(r => r.data);
+
+// Users (admin)
+export const getUsers = () =>
+  api.get<ManagedUser[]>('/users').then(r => r.data);
+export const createUser = (data: { username: string; password: string; role?: UserRole }) =>
+  api.post<ManagedUser>('/users', data).then(r => r.data);
+export const updateUser = (id: number, data: Partial<{ password: string; is_active: number; role: UserRole }>) =>
+  api.put<ManagedUser>(`/users/${id}`, data).then(r => r.data);
+export const deleteUser = (id: number) =>
+  api.delete(`/users/${id}`);
 
 // Books
 export const getBooks = (q?: string, status?: string) =>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
-import { BookOpen, LayoutDashboard, BookMarked, Star, Palette } from 'lucide-react';
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
 
 type Theme = 'dark' | 'light' | 'purple' | 'rainbow' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'glass-light' | 'glass-rich';
 
@@ -58,10 +59,17 @@ const SPARKLES = [
 ] as const;
 
 export default function Layout() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem('book_app_theme') as Theme) || 'dark'
   );
   const isGlassTheme = theme === 'glass-light' || theme === 'glass-rich';
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/login', { replace: true });
+  };
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -188,7 +196,22 @@ export default function Layout() {
             <BookMarked />
             Series
           </NavLink>
+          {user?.role === 'admin' && (
+            <NavLink
+              to="/users"
+              className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
+            >
+              <Users />
+              Users
+            </NavLink>
+          )}
         </nav>
+        <div className="sidebar__account">
+          <span className="sidebar__account-username">{user?.username}</span>
+          <button className="btn btn--ghost btn--sm btn--icon" title="Log out" onClick={handleLogout}>
+            <LogOut size={14} />
+          </button>
+        </div>
         <div className="sidebar__theme">
           <div className="form-group" style={{ width: '100%' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-3)', marginBottom: '4px' }}>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
+import { getMe, login as apiLogin, logout as apiLogout, registerUnauthorizedHandler, unregisterUnauthorizedHandler } from '../api';
+import type { AuthUser } from '../types';
+
+interface AuthCtx {
+  user: AuthUser | null;
+  loading: boolean;
+  login: (username: string, password: string) => Promise<string | undefined>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthCtx>({
+  user: null,
+  loading: true,
+  login: async () => undefined,
+  logout: async () => {},
+});
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const handler = () => setUser(null);
+    registerUnauthorizedHandler(handler);
+    return () => unregisterUnauthorizedHandler(handler);
+  }, []);
+
+  useEffect(() => {
+    getMe()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = useCallback(async (username: string, password: string) => {
+    try {
+      const u = await apiLogin(username, password);
+      setUser(u);
+      return undefined;
+    } catch (err: any) {
+      if (err?.response?.status === 429) return 'Too many attempts, try later.';
+      return err?.response?.data?.error || 'Invalid username or password';
+    }
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } finally {
+      setUser(null);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,72 @@
+import { useState, FormEvent } from 'react';
+import { useLocation, Navigate } from 'react-router-dom';
+import { BookOpen } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+export default function LoginPage() {
+  const { user, loading, login } = useAuth();
+  const location = useLocation();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!loading && user) {
+    const from = (location.state as { from?: { pathname: string; search: string } })?.from;
+    return <Navigate to={from ? `${from.pathname}${from.search}` : '/'} replace />;
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!username.trim() || !password) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const err = await login(username.trim(), password);
+      if (err) setError(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <div className="auth-card__brand">
+          <BookOpen size={28} />
+          <span>V&apos;s Books</span>
+        </div>
+        <h1 className="auth-card__title">Sign in</h1>
+        <form onSubmit={handleSubmit}>
+          {error && <p className="form-error">{error}</p>}
+          <div className="form-group">
+            <label className="form-label" htmlFor="username">Username</label>
+            <input
+              id="username"
+              className="form-input"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              autoFocus
+              autoComplete="username"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              className="form-input"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+          <button type="submit" className="btn btn--primary auth-card__submit" disabled={submitting}>
+            {submitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useState, FormEvent } from 'react';
+import { Plus, KeyRound, Ban, CheckCircle2, Trash2, ShieldAlert } from 'lucide-react';
+import { getUsers, createUser, updateUser, deleteUser } from '../api';
+import type { ManagedUser, UserRole } from '../types';
+import { useAuth } from '../context/AuthContext';
+import Modal from '../components/Modal';
+import { useToast } from '../components/Toast';
+
+export default function UsersPage() {
+  const { user: me } = useAuth();
+  const { toast } = useToast();
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [showAdd, setShowAdd] = useState(false);
+  const [newUsername, setNewUsername] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [newRole, setNewRole] = useState<UserRole>('user');
+  const [createError, setCreateError] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [resetTarget, setResetTarget] = useState<ManagedUser | null>(null);
+  const [resetPassword, setResetPassword] = useState('');
+  const [resetError, setResetError] = useState('');
+  const [resetting, setResetting] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState<ManagedUser | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(() => {
+    getUsers()
+      .then(setUsers)
+      .catch(() => toast('error', 'Failed to load users.'))
+      .finally(() => setLoading(false));
+  }, [toast]);
+
+  useEffect(() => {
+    if (me?.role === 'admin') load();
+    else setLoading(false);
+  }, [me, load]);
+
+  if (me && me.role !== 'admin') {
+    return (
+      <div className="page">
+        <div className="empty-state">
+          <ShieldAlert size={36} />
+          <p>You don&apos;t have access to this page.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!newUsername.trim() || newPassword.length < 8) {
+      setCreateError('Username is required and password must be at least 8 characters.');
+      return;
+    }
+    setCreating(true);
+    setCreateError('');
+    try {
+      const created = await createUser({ username: newUsername.trim(), password: newPassword, role: newRole });
+      setUsers(u => [...u, created]);
+      setShowAdd(false);
+      setNewUsername('');
+      setNewPassword('');
+      setNewRole('user');
+      toast('success', 'User created.');
+    } catch (err: any) {
+      setCreateError(err.response?.data?.error || 'Failed to create user.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleToggleActive = async (u: ManagedUser) => {
+    try {
+      const updated = await updateUser(u.id, { is_active: u.is_active ? 0 : 1 });
+      setUsers(list => list.map(x => (x.id === u.id ? updated : x)));
+      toast('success', updated.is_active ? 'User activated.' : 'User deactivated.');
+    } catch (err: any) {
+      toast('error', err.response?.data?.error || 'Failed to update user.');
+    }
+  };
+
+  const handleResetPassword = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!resetTarget) return;
+    if (resetPassword.length < 8) {
+      setResetError('Password must be at least 8 characters.');
+      return;
+    }
+    setResetting(true);
+    setResetError('');
+    try {
+      await updateUser(resetTarget.id, { password: resetPassword });
+      toast('success', `Password reset for ${resetTarget.username}.`);
+      setResetTarget(null);
+      setResetPassword('');
+    } catch (err: any) {
+      setResetError(err.response?.data?.error || 'Failed to reset password.');
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteUser(deleteTarget.id);
+      setUsers(list => list.filter(x => x.id !== deleteTarget.id));
+      toast('success', 'User deleted.');
+      setDeleteTarget(null);
+    } catch (err: any) {
+      toast('error', err.response?.data?.error || 'Failed to delete user.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="page">
+        <div className="skeleton" style={{ height: 28, width: 160, marginBottom: 24 }} />
+        <div className="skeleton skeleton--row" style={{ marginBottom: 12 }} />
+        <div className="skeleton skeleton--row" style={{ marginBottom: 12 }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h1>Users</h1>
+          <p className="page-subtitle">{users.length} user{users.length !== 1 ? 's' : ''}</p>
+        </div>
+        <div className="page-header__actions">
+          <button className="btn btn--primary" onClick={() => setShowAdd(true)}>
+            <Plus size={14} />
+            Add User
+          </button>
+        </div>
+      </div>
+
+      {users.length === 0 ? (
+        <div className="empty-state">
+          <p>No users yet.</p>
+        </div>
+      ) : (
+        <div className="user-list">
+          <div className="user-row user-row--head">
+            <span>Username</span>
+            <span>Role</span>
+            <span>Status</span>
+            <span>Created</span>
+            <span>Actions</span>
+          </div>
+          {users.map(u => {
+            const isSelf = me?.id === u.id;
+            return (
+              <div key={u.id} className="user-row">
+                <span className="user-row__username">{u.username}</span>
+                <span className="tag">{u.role}</span>
+                <span className={`status-badge status-badge--${u.is_active ? 'read' : 'unread'}`}>
+                  {u.is_active ? 'Active' : 'Inactive'}
+                </span>
+                <span className="user-row__date">{new Date(u.created_at).toLocaleDateString()}</span>
+                <span className="user-row__actions">
+                  <button
+                    className="btn btn--secondary btn--sm btn--icon"
+                    title="Reset password"
+                    onClick={() => { setResetTarget(u); setResetPassword(''); setResetError(''); }}
+                  >
+                    <KeyRound size={14} />
+                  </button>
+                  <button
+                    className="btn btn--secondary btn--sm btn--icon"
+                    title={u.is_active ? 'Deactivate' : 'Activate'}
+                    disabled={isSelf}
+                    onClick={() => handleToggleActive(u)}
+                  >
+                    {u.is_active ? <Ban size={14} /> : <CheckCircle2 size={14} />}
+                  </button>
+                  <button
+                    className="btn btn--danger btn--sm btn--icon"
+                    title="Delete"
+                    disabled={isSelf}
+                    onClick={() => setDeleteTarget(u)}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showAdd && (
+        <Modal title="Add User" onClose={() => setShowAdd(false)} size="sm">
+          <form onSubmit={handleCreate}>
+            {createError && <p className="form-error">{createError}</p>}
+            <div className="form-group">
+              <label className="form-label" htmlFor="new-username">Username</label>
+              <input
+                id="new-username"
+                className="form-input"
+                value={newUsername}
+                onChange={e => setNewUsername(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="new-password">Password</label>
+              <input
+                id="new-password"
+                type="password"
+                className="form-input"
+                value={newPassword}
+                onChange={e => setNewPassword(e.target.value)}
+                autoComplete="new-password"
+              />
+            </div>
+            <div className="form-group">
+              <label className="form-label" htmlFor="new-role">Role</label>
+              <select
+                id="new-role"
+                className="form-select"
+                value={newRole}
+                onChange={e => setNewRole(e.target.value as UserRole)}
+              >
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <button type="submit" className="btn btn--primary" disabled={creating} style={{ marginTop: 8 }}>
+              {creating ? 'Creating…' : 'Create User'}
+            </button>
+          </form>
+        </Modal>
+      )}
+
+      {resetTarget && (
+        <Modal title={`Reset password for ${resetTarget.username}`} onClose={() => setResetTarget(null)} size="sm">
+          <form onSubmit={handleResetPassword}>
+            {resetError && <p className="form-error">{resetError}</p>}
+            <div className="form-group">
+              <label className="form-label" htmlFor="reset-password">New password</label>
+              <input
+                id="reset-password"
+                type="password"
+                className="form-input"
+                value={resetPassword}
+                onChange={e => setResetPassword(e.target.value)}
+                autoFocus
+                autoComplete="new-password"
+              />
+            </div>
+            <button type="submit" className="btn btn--primary" disabled={resetting} style={{ marginTop: 8 }}>
+              {resetting ? 'Resetting…' : 'Reset Password'}
+            </button>
+          </form>
+        </Modal>
+      )}
+
+      {deleteTarget && (
+        <Modal
+          title="Delete user"
+          onClose={() => setDeleteTarget(null)}
+          size="sm"
+          footer={
+            <>
+              <button className="btn btn--secondary" onClick={() => setDeleteTarget(null)}>Cancel</button>
+              <button className="btn btn--danger" onClick={handleDelete} disabled={deleting}>
+                {deleting ? 'Deleting…' : 'Delete User'}
+              </button>
+            </>
+          }
+        >
+          <p>
+            Delete <strong>{deleteTarget.username}</strong>? This permanently deletes their entire library
+            (books, series, notes). This cannot be undone.
+          </p>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -786,6 +786,55 @@
   }
 }
 
+// ── User List (Users admin page) ────────────────────────────────────────
+.user-list {
+  display: flex;
+  flex-direction: column;
+  gap: $space-2;
+}
+
+.user-row {
+  display: grid;
+  grid-template-columns: 1.5fr 0.8fr 0.9fr 1fr auto;
+  align-items: center;
+  gap: $space-3;
+  padding: $space-3 $space-4;
+  background: $bg-card;
+  border: var(--glass-border, 1px solid $border);
+  border-radius: $radius-lg;
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow, none);
+
+  &--head {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0 $space-4;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: $text-3;
+  }
+
+  &__username {
+    font-weight: 600;
+    color: $text-1;
+    @include truncate;
+  }
+
+  &__date {
+    font-size: 0.8125rem;
+    color: $text-3;
+  }
+
+  &__actions {
+    display: flex;
+    gap: $space-2;
+    justify-content: flex-end;
+  }
+}
+
 // ── Cover Picker ──────────────────────────────────────────────────────────
 .cover-picker {
   display: flex;

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -50,6 +50,22 @@
   flex: 1;
 }
 
+.sidebar__account {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $space-2;
+  padding: $space-3 $space-4;
+  border-top: 1px solid $border;
+
+  &-username {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: $text-2;
+    @include truncate;
+  }
+}
+
 .sidebar__theme {
   display: flex;
   flex-wrap: wrap;
@@ -141,4 +157,56 @@
   color: $text-3;
   font-size: 0.875rem;
   margin-top: $space-1;
+}
+
+// ── Auth (Login) Page ────────────────────────────────────────────────────
+.auth-page {
+  min-height: 100vh;
+  @include flex-center;
+  background: $bg-base;
+  padding: $space-4;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 340px;
+  background: $bg-card;
+  border: var(--glass-border, 1px solid $border);
+  border-radius: $radius-lg;
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow, none);
+  padding: $space-8 $space-6 $space-6;
+
+  &__brand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $space-2;
+    color: $accent;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    margin-bottom: $space-6;
+  }
+
+  &__title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    text-align: center;
+    margin-bottom: $space-6;
+    color: $text-1;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: $space-4;
+  }
+
+  &__submit {
+    width: 100%;
+    justify-content: center;
+    margin-top: $space-2;
+  }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,21 @@
 export type BookStatus = 'unread' | 'reading' | 'read' | 'wishlist';
 
+export type UserRole = 'admin' | 'user';
+
+export interface AuthUser {
+  id: number;
+  username: string;
+  role: UserRole;
+}
+
+export interface ManagedUser {
+  id: number;
+  username: string;
+  role: UserRole;
+  is_active: number;
+  created_at: string;
+}
+
 export interface Book {
   id: number;
   title: string;

--- a/k8s/base/admin-secret.example.yaml
+++ b/k8s/base/admin-secret.example.yaml
@@ -1,0 +1,18 @@
+# Example only — NOT included in kustomization.yaml and must never be committed
+# with real values. Create the real secret out-of-band (or via SOPS):
+#
+#   kubectl -n vs-book-app create secret generic vs-book-app-admin \
+#     --from-literal=ADMIN_USERNAME=<username> \
+#     --from-literal=ADMIN_PASSWORD=<strong password>
+#
+# The app seeds this admin only while the users table is empty; afterwards the
+# secret is inert and further user management happens in the app's admin UI.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vs-book-app-admin
+  namespace: vs-book-app
+type: Opaque
+stringData:
+  ADMIN_USERNAME: change-me
+  ADMIN_PASSWORD: change-me

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -24,6 +24,20 @@ spec:
               value: "3000"
             - name: DB_PATH
               value: /data/books.db
+            # Seeds the first admin only while the users table is empty;
+            # rotating these values later has no effect (use the in-app admin UI).
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: vs-book-app-admin
+                  key: ADMIN_USERNAME
+                  optional: true
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: vs-book-app-admin
+                  key: ADMIN_PASSWORD
+                  optional: true
           ports:
             - containerPort: 3000
               name: http


### PR DESCRIPTION
## Summary
- Session-cookie auth (bcryptjs hashes, sha256-hashed tokens in SQLite, httpOnly/SameSite=Lax/Secure cookie, 30-day sliding expiry) with login rate limiting
- Admin-created users only (no self-registration); first admin seeded from ADMIN_USERNAME/ADMIN_PASSWORD env when users table is empty; existing library backfilled to that admin
- Per-user libraries: user_id ownership on books and series (notes via cascade); series unique constraint rebuilt to (user_id, name); all routes scoped, cross-user ids return 404
- Frontend: LoginPage, AuthContext with /me probe + 401 interceptor, RequireAuth route guard, admin-only Users page (create/reset password/deactivate/delete), logout in sidebar
- k8s: deployment reads seed credentials from optional Secret vs-book-app-admin (example manifest documents out-of-band creation)

Design doc: docs/plans/2026-07-11-user-accounts-design.md

## Verification
- tsc builds clean (backend + frontend)
- curl smoke: login 401/200, cookie round-trip, scoped routes 401 without session, logout invalidates
- Browser QA (Chrome): guard redirect, bad-creds error, admin login, user creation via Users page, second-user login sees empty library and no Users nav, direct /users as non-admin shows forbidden

## Deployment notes (infra handoff)
- Create Secret before rollout: `kubectl -n vs-book-app create secret generic vs-book-app-admin --from-literal=ADMIN_USERNAME=... --from-literal=ADMIN_PASSWORD=...` (seed only runs while users table is empty; rotate passwords via the in-app admin UI afterwards)
- `trust proxy` is pinned to 2 hops (Cloudflare -> Traefik); adjust if the ingress chain changes
- Open item: restrict origin so only Cloudflare IPs reach Traefik for this host, else the app is reachable around Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)