### PR TITLE
feat: expose books.zakharhome.org and deploy user-accounts image

### DIFF
--- a/clusters/themachine/cloudflared/setup-tunnel.sh
+++ b/clusters/themachine/cloudflared/setup-tunnel.sh
@@ -17,7 +17,11 @@ set -euo pipefail
 API="https://api.cloudflare.com/client/v4"
 TUNNEL_NAME="themachine"
 ZONE_NAME="zakharhome.org"
-HOSTNAME="synth.${ZONE_NAME}"
+# All hostnames route to in-cluster Traefik; host-based Ingress does the rest.
+HOSTNAMES=(
+  "synth.${ZONE_NAME}"
+  "books.${ZONE_NAME}"
+)
 ORIGIN_SERVICE="http://traefik.kube-system.svc.cluster.local:80"
 
 cf() {
@@ -55,27 +59,27 @@ else
   echo "    reusing tunnel $TUNNEL_ID"
 fi
 
-echo "==> Ingress config: $HOSTNAME -> $ORIGIN_SERVICE"
-cf PUT "/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/configurations" "$(jq -n \
-  --arg host "$HOSTNAME" --arg svc "$ORIGIN_SERVICE" '{
-  config: { ingress: [
-    { hostname: $host, service: $svc },
-    { service: "http_status:404" }
-  ]}}')" >/dev/null
+echo "==> Ingress config: ${HOSTNAMES[*]} -> $ORIGIN_SERVICE"
+INGRESS_RULES=$(printf '%s\n' "${HOSTNAMES[@]}" | jq -R --arg svc "$ORIGIN_SERVICE" \
+  '{hostname: ., service: $svc}' | jq -s '. + [{service: "http_status:404"}]')
+cf PUT "/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/configurations" \
+  "$(jq -n --argjson rules "$INGRESS_RULES" '{config: {ingress: $rules}}')" >/dev/null
 echo "    applied"
 
-echo "==> DNS: $HOSTNAME CNAME ${TUNNEL_ID}.cfargotunnel.com (proxied)"
-RECORD_ID=$(cf GET "/zones/$ZONE_ID/dns_records?type=CNAME&name=$HOSTNAME" \
-  | jq -r '.[0].id // empty')
-DNS_BODY=$(jq -n --arg name "$HOSTNAME" --arg target "${TUNNEL_ID}.cfargotunnel.com" \
-  '{type:"CNAME", name:$name, content:$target, proxied:true, ttl:1}')
-if [ -z "$RECORD_ID" ]; then
-  cf POST "/zones/$ZONE_ID/dns_records" "$DNS_BODY" >/dev/null
-  echo "    created"
-else
-  cf PUT "/zones/$ZONE_ID/dns_records/$RECORD_ID" "$DNS_BODY" >/dev/null
-  echo "    updated"
-fi
+for HOSTNAME in "${HOSTNAMES[@]}"; do
+  echo "==> DNS: $HOSTNAME CNAME ${TUNNEL_ID}.cfargotunnel.com (proxied)"
+  RECORD_ID=$(cf GET "/zones/$ZONE_ID/dns_records?type=CNAME&name=$HOSTNAME" \
+    | jq -r '.[0].id // empty')
+  DNS_BODY=$(jq -n --arg name "$HOSTNAME" --arg target "${TUNNEL_ID}.cfargotunnel.com" \
+    '{type:"CNAME", name:$name, content:$target, proxied:true, ttl:1}')
+  if [ -z "$RECORD_ID" ]; then
+    cf POST "/zones/$ZONE_ID/dns_records" "$DNS_BODY" >/dev/null
+    echo "    created"
+  else
+    cf PUT "/zones/$ZONE_ID/dns_records/$RECORD_ID" "$DNS_BODY" >/dev/null
+    echo "    updated"
+  fi
+done
 
 echo "==> Tunnel token"
 TOKEN=$(cf GET "/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/token" | jq -r '.')
@@ -90,5 +94,5 @@ Done. On themachine, install the token secret (cloudflared deployment reads it):
     --dry-run=client -o yaml | kubectl apply -f -
 
 Then let Flux reconcile (or: flux reconcile kustomization flux-system --with-source)
-and verify: https://$HOSTNAME
+and verify: ${HOSTNAMES[*]/#/https:\/\/}
 EOF

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:4f75ee7add2c3821d3c3cb29edffbf0b87e082b4ce533bf1932cd566d93dabab
+          image: ghcr.io/mzakhar/vs-book-app@sha256:3f072d6827da3fefe4ac29d51c9962ecc97a654e8527f6edb930bfa0ac52b6cb
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -17,3 +17,55 @@ spec:
                 name: vs-book-app
                 port:
                   number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vs-book-app-external
+  namespace: vs-book-app
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: vs-book-app-vs-book-app-strip-books@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: books.zakharhome.org
+      http:
+        paths:
+          - path: /books
+            pathType: Prefix
+            backend:
+              service:
+                name: vs-book-app
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vs-book-app-external-root
+  namespace: vs-book-app
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: vs-book-app-redirect-root-to-books@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: books.zakharhome.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vs-book-app
+                port:
+                  number: 80
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-root-to-books
+  namespace: vs-book-app
+spec:
+  redirectRegex:
+    regex: ^(https?)://books\.zakharhome\.org/?$
+    replacement: ${1}://books.zakharhome.org/books/


### PR DESCRIPTION
- Pin image digest to post-auth build (`afe50fa` → `sha256:3f072d68…`) — publish workflow does not bump the digest, cluster was still on the pre-auth image
- External Ingress: `books.zakharhome.org/books/` (reuses strip-books middleware) + root → /books/ redirect middleware
- setup-tunnel.sh: hostname list (synth + books), loops DNS records, single tunnel config PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)