### PR TITLE
fix: root redirect targets https

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -67,5 +67,5 @@ metadata:
   namespace: vs-book-app
 spec:
   redirectRegex:
-    regex: ^(https?)://books\.zakharhome\.org/?$
-    replacement: ${1}://books.zakharhome.org/books/
+    regex: ^https?://books\.zakharhome\.org/?$
+    replacement: https://books.zakharhome.org/books/


### PR DESCRIPTION
Redirect middleware echoed origin-side scheme (http via tunnel), downgrading https visitors. Hardcode https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)