### PR TITLE
feat: user profiles — screen name, genres, favorite book, avatar

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -83,6 +83,10 @@ export async function getDb(): Promise<Database> {
     `ALTER TABLE books ADD COLUMN description     TEXT`,
     `ALTER TABLE books  ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE`,
     `ALTER TABLE series ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE CASCADE`,
+    `ALTER TABLE users ADD COLUMN screen_name TEXT`,
+    `ALTER TABLE users ADD COLUMN avatar_url TEXT`,
+    `ALTER TABLE users ADD COLUMN favorite_genres TEXT`,
+    `ALTER TABLE users ADD COLUMN favorite_book_id INTEGER REFERENCES books(id) ON DELETE SET NULL`,
   ];
   for (const sql of migrations) {
     try { await _db.run(sql); } catch { /* column already exists */ }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,7 +9,7 @@ import seriesRouter from './routes/series';
 import authRouter from './routes/auth';
 import usersRouter from './routes/users';
 import { getDb } from './database';
-import { requireAuth, requireAdmin } from './middleware/auth';
+import { requireAuth } from './middleware/auth';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -23,7 +23,7 @@ app.set('trust proxy', IS_PROD ? 2 : false);
 if (!IS_PROD) {
   app.use(cors({ origin: ['http://localhost:5173', 'http://localhost:5174', 'http://localhost:5175'] }));
 }
-app.use(express.json());
+app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());
 
 const loginLimiter = rateLimit({
@@ -34,7 +34,7 @@ const loginLimiter = rateLimit({
 
 app.use('/api/auth/login', loginLimiter);
 app.use('/api/auth', authRouter);
-app.use('/api/users', requireAuth, requireAdmin, usersRouter);
+app.use('/api/users', requireAuth, usersRouter);
 app.use('/api/books', requireAuth, booksRouter);
 app.use('/api/notes', requireAuth, notesRouter);
 app.use('/api/series', requireAuth, seriesRouter);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -86,19 +86,21 @@ const PROFILE_COLUMNS = `id, username, screen_name, avatar_url, favorite_genres,
 
 // --- Routes ---
 
-router.get('/', asyncHandler(async (req: Request, res: Response) => {
+// Public directory — same shape for every caller so the Readers page
+// works for admins too; the management list lives at /admin.
+router.get('/', asyncHandler(async (_req: Request, res: Response) => {
   const db = await getDb();
-
-  if (req.user!.role === 'admin') {
-    const users = await db.all(
-      `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
-    );
-    return res.json(users);
-  }
-
   const users = await db.all(
     `SELECT id, COALESCE(screen_name, username) as screen_name, avatar_url
      FROM users WHERE is_active = 1 ORDER BY id ASC`
+  );
+  res.json(users);
+}));
+
+router.get('/admin', requireAdmin, asyncHandler(async (_req: Request, res: Response) => {
+  const db = await getDb();
+  const users = await db.all(
+    `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
   );
   res.json(users);
 }));

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,19 +1,109 @@
 import { Router, Request, Response } from 'express';
 import bcrypt from 'bcryptjs';
+import { Database } from 'sqlite';
 import { getDb } from '../database';
 import { asyncHandler } from '../asyncHandler';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 
-router.get('/', asyncHandler(async (_req: Request, res: Response) => {
+type ValidationResult<T> = { ok: true; value: T } | { ok: false };
+
+// --- Pure validators (profile PUT) ---
+
+function validateScreenName(input: unknown): ValidationResult<string | null> {
+  if (input === null || input === undefined) return { ok: true, value: null };
+  if (typeof input !== 'string') return { ok: false };
+  const trimmed = input.trim();
+  if (trimmed.length > 40) return { ok: false };
+  return { ok: true, value: trimmed === '' ? null : trimmed };
+}
+
+function validateAvatarUrl(input: unknown): ValidationResult<string | null> {
+  if (input === null || input === undefined) return { ok: true, value: null };
+  if (typeof input !== 'string') return { ok: false };
+  if (!input.startsWith('data:image/')) return { ok: false };
+  if (input.length > 500000) return { ok: false };
+  return { ok: true, value: input };
+}
+
+function validateFavoriteGenres(input: unknown): ValidationResult<string[]> {
+  if (input === null || input === undefined) return { ok: true, value: [] };
+  if (!Array.isArray(input)) return { ok: false };
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of input) {
+    if (typeof item !== 'string') return { ok: false };
+    const trimmed = item.trim();
+    if (trimmed === '') continue;
+    if (trimmed.length > 40) return { ok: false };
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  if (result.length > 10) return { ok: false };
+  return { ok: true, value: result };
+}
+
+function parseGenres(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.filter((g): g is string => typeof g === 'string');
+  } catch { /* malformed json — treat as empty */ }
+  return [];
+}
+
+// --- Shell helpers (need db) ---
+
+async function resolveFavoriteBookId(db: Database, input: unknown, userId: number): Promise<ValidationResult<number | null>> {
+  if (input === null || input === undefined) return { ok: true, value: null };
+  if (!Number.isInteger(input)) return { ok: false };
+  const book = await db.get(`SELECT id FROM books WHERE id = ? AND user_id = ?`, input, userId);
+  if (!book) return { ok: false };
+  return { ok: true, value: input as number };
+}
+
+async function buildProfileResponse(db: Database, row: any, coalesceScreenName: boolean) {
+  let favoriteBook = null;
+  if (row.favorite_book_id) {
+    favoriteBook = (await db.get(
+      `SELECT id, title, author, cover_url FROM books WHERE id = ?`,
+      row.favorite_book_id
+    )) || null;
+  }
+  return {
+    id: row.id,
+    username: row.username,
+    screen_name: coalesceScreenName ? (row.screen_name || row.username) : (row.screen_name ?? null),
+    avatar_url: row.avatar_url ?? null,
+    favorite_genres: parseGenres(row.favorite_genres),
+    favorite_book: favoriteBook,
+  };
+}
+
+const PROFILE_COLUMNS = `id, username, screen_name, avatar_url, favorite_genres, favorite_book_id`;
+
+// --- Routes ---
+
+router.get('/', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
+
+  if (req.user!.role === 'admin') {
+    const users = await db.all(
+      `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
+    );
+    return res.json(users);
+  }
+
   const users = await db.all(
-    `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
+    `SELECT id, COALESCE(screen_name, username) as screen_name, avatar_url
+     FROM users WHERE is_active = 1 ORDER BY id ASC`
   );
   res.json(users);
 }));
 
-router.post('/', asyncHandler(async (req: Request, res: Response) => {
+router.post('/', requireAdmin, asyncHandler(async (req: Request, res: Response) => {
   const { username, password, role } = req.body;
   if (!username || !username.trim()) return res.status(400).json({ error: 'Username is required' });
   if (!password || password.length < 8) return res.status(400).json({ error: 'Password must be at least 8 characters' });
@@ -36,7 +126,54 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
   res.status(201).json(user);
 }));
 
-router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
+// Registered before /:id/profile so "me" is never captured by the :id param.
+router.get('/me/profile', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  const row = await db.get(`SELECT ${PROFILE_COLUMNS} FROM users WHERE id = ?`, req.user!.id);
+  if (!row) return res.status(404).json({ error: 'User not found' });
+  res.json(await buildProfileResponse(db, row, false));
+}));
+
+router.put('/me/profile', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  const { screen_name, avatar_url, favorite_genres, favorite_book_id } = req.body;
+
+  const screenNameResult = validateScreenName(screen_name);
+  if (!screenNameResult.ok) return res.status(400).json({ error: 'Invalid screen_name' });
+
+  const avatarResult = validateAvatarUrl(avatar_url);
+  if (!avatarResult.ok) return res.status(400).json({ error: 'Invalid avatar_url' });
+
+  const genresResult = validateFavoriteGenres(favorite_genres);
+  if (!genresResult.ok) return res.status(400).json({ error: 'Invalid favorite_genres' });
+
+  const favoriteBookResult = await resolveFavoriteBookId(db, favorite_book_id, req.user!.id);
+  if (!favoriteBookResult.ok) return res.status(400).json({ error: 'Invalid favorite_book_id' });
+
+  await db.run(
+    `UPDATE users SET screen_name = ?, avatar_url = ?, favorite_genres = ?, favorite_book_id = ? WHERE id = ?`,
+    screenNameResult.value,
+    avatarResult.value,
+    JSON.stringify(genresResult.value),
+    favoriteBookResult.value,
+    req.user!.id
+  );
+
+  const row = await db.get(`SELECT ${PROFILE_COLUMNS} FROM users WHERE id = ?`, req.user!.id);
+  res.json(await buildProfileResponse(db, row, false));
+}));
+
+router.get('/:id/profile', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  const row = await db.get(
+    `SELECT ${PROFILE_COLUMNS}, is_active FROM users WHERE id = ?`,
+    req.params.id
+  );
+  if (!row || !row.is_active) return res.status(404).json({ error: 'User not found' });
+  res.json(await buildProfileResponse(db, row, true));
+}));
+
+router.put('/:id', requireAdmin, asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
   const existing = await db.get(`SELECT * FROM users WHERE id = ?`, req.params.id);
   if (!existing) return res.status(404).json({ error: 'User not found' });
@@ -72,7 +209,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   res.json(user);
 }));
 
-router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
+router.delete('/:id', requireAdmin, asyncHandler(async (req: Request, res: Response) => {
   if (Number(req.params.id) === req.user!.id) {
     return res.status(400).json({ error: 'Cannot delete your own account' });
   }

--- a/docs/plans/2026-07-11-user-profiles-design.md
+++ b/docs/plans/2026-07-11-user-profiles-design.md
@@ -1,0 +1,105 @@
+# User Profiles — Design
+
+**Date:** 2026-07-11
+**Builds on:** user accounts (PR #17 — `users` table, session auth, per-user libraries)
+
+## Scope
+
+Each user gets a public profile: screen name, favorite genres, current favorite
+book, profile picture. Visible to all logged-in users; editable only by the
+owner.
+
+Out of scope (YAGNI): bios, reading stats on public profiles, visibility of
+other users' libraries, admin profile moderation, avatar cropping UI.
+
+## Data model
+
+New columns on `users` via the existing migrations array in
+`backend/src/database.ts`:
+
+```sql
+ALTER TABLE users ADD COLUMN screen_name      TEXT
+ALTER TABLE users ADD COLUMN avatar_url       TEXT      -- data URL
+ALTER TABLE users ADD COLUMN favorite_genres  TEXT      -- JSON array
+ALTER TABLE users ADD COLUMN favorite_book_id INTEGER REFERENCES books(id) ON DELETE SET NULL
+```
+
+- `screen_name` optional; display falls back to `username`. Not unique —
+  username already carries uniqueness.
+- `favorite_genres` stored as JSON text. Small list, never queried per-genre;
+  a join table is overkill.
+- `favorite_book_id` FK with `ON DELETE SET NULL` — deleting the book clears
+  the favorite. Backend validates the picked book belongs to the caller.
+- Avatar stored as data URL, same pattern as book covers. Client downscales
+  to 256×256 (canvas, JPEG) before save; backend rejects payloads > 500KB.
+
+## API
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `GET /api/users/me/profile` | self | Own profile for the edit form |
+| `PUT /api/users/me/profile` | self | Update screen name, genres, avatar, favorite book |
+| `GET /api/users` | any logged-in | Directory: id, screen name, avatar. Existing admin variant keeps full fields; non-admin callers get public fields only |
+| `GET /api/users/:id/profile` | any logged-in | Public profile; joins `books` for favorite book (id, title, author, cover_url) |
+
+Public payloads never include `password_hash`, `role`, or `is_active`.
+Backend serializes `favorite_genres` to a real array at the API edge.
+
+### Validation (`PUT /api/users/me/profile`)
+
+- `screen_name`: trim, max 40 chars; empty string stored as NULL
+- `avatar_url`: must start `data:image/`, reject > 500KB (bump body limit on
+  this route only if the Express default blocks it)
+- `favorite_genres`: array of strings, trimmed, deduped, max 10
+- `favorite_book_id`: must exist and be owned by the caller, else 400
+
+## Frontend
+
+Types (`frontend/src/types/index.ts`):
+
+```ts
+UserProfile = { id, username, screen_name, avatar_url,
+                favorite_genres: string[],
+                favorite_book: { id, title, author, cover_url } | null }
+UserSummary = { id, screen_name, avatar_url }
+```
+
+Routes (inside `Layout`):
+
+| Path | Page |
+|---|---|
+| `/users` | ReadersPage — grid of avatar + screen-name cards |
+| `/users/:id` | ProfilePage — avatar, screen name, genre chips, favorite book card; Edit button on own profile |
+
+Edit form is a modal (existing `Modal`, BookForm patterns):
+
+- Screen name text input
+- Genre multi-select — chips built from distinct genres in the user's own
+  library, unioned with currently-saved genres so a saved genre whose books
+  were deleted doesn't silently disappear
+- Favorite book — searchable select over own books with cover thumbnails
+- Avatar — clipboard paste zone (same handler pattern as BookForm cover
+  paste), canvas downscale, preview + remove
+
+Layout header: avatar (or initial-letter fallback circle) + screen name on the
+right with a dropdown (Edit profile, Logout); "Readers" nav link alongside
+Library/Series.
+
+API client (`frontend/src/api/index.ts`): `getMyProfile`, `updateMyProfile`,
+`getUsers`, `getUserProfile(id)`.
+
+Styling: SASS with existing theme variables; all three themes (dark, light,
+purple) covered.
+
+## Edge cases
+
+- Favorite book deleted → FK sets NULL; profile renders without the card
+- No avatar → initial-letter circle, theme-colored
+- Deactivated users (`is_active = 0`) excluded from the directory; direct
+  profile fetch 404s
+- Pre-migration users: all new columns NULL; every surface has a fallback
+
+## Testing
+
+Repo has no test suite; keeping that. Route-handler validation stays small —
+extract pure validators if it grows.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import BookDetail from './pages/BookDetail';
 import SeriesPage from './pages/SeriesPage';
 import Wishlist from './pages/Wishlist';
 import UsersPage from './pages/UsersPage';
+import ReadersPage from './pages/ReadersPage';
+import ProfilePage from './pages/ProfilePage';
 
 function RequireAuth({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth();
@@ -40,7 +42,9 @@ export default function App() {
               <Route path="wishlist" element={<Wishlist />} />
               <Route path="books/:id" element={<BookDetail />} />
               <Route path="series" element={<SeriesPage />} />
-              <Route path="users" element={<UsersPage />} />
+              <Route path="users" element={<ReadersPage />} />
+              <Route path="users/:id" element={<ProfilePage />} />
+              <Route path="admin/users" element={<UsersPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Route>
           </Routes>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { AuthUser, Book, BookStats, ManagedUser, Note, Series, UserRole } from '../types';
+import type { AuthUser, Book, BookStats, ManagedUser, Note, Series, UserRole, UserProfile, UserSummary } from '../types';
 
 const api = axios.create({ baseURL: import.meta.env.VITE_API_BASE || '/api' });
 
@@ -43,6 +43,16 @@ export const updateUser = (id: number, data: Partial<{ password: string; is_acti
   api.put<ManagedUser>(`/users/${id}`, data).then(r => r.data);
 export const deleteUser = (id: number) =>
   api.delete(`/users/${id}`);
+
+// Profiles
+export const getUserProfiles = () =>
+  api.get<UserSummary[]>('/users').then(r => r.data);
+export const getUserProfile = (id: number) =>
+  api.get<UserProfile>(`/users/${id}/profile`).then(r => r.data);
+export const getMyProfile = () =>
+  api.get<UserProfile>('/users/me/profile').then(r => r.data);
+export const updateMyProfile = (data: { screen_name: string | null; avatar_url: string | null; favorite_genres: string[]; favorite_book_id: number | null }) =>
+  api.put<UserProfile>('/users/me/profile', data).then(r => r.data);
 
 // Books
 export const getBooks = (q?: string, status?: string) =>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -36,7 +36,7 @@ export const getMe = () =>
 
 // Users (admin)
 export const getUsers = () =>
-  api.get<ManagedUser[]>('/users').then(r => r.data);
+  api.get<ManagedUser[]>('/users/admin').then(r => r.data);
 export const createUser = (data: { username: string; password: string; role?: UserRole }) =>
   api.post<ManagedUser>('/users', data).then(r => r.data);
 export const updateUser = (id: number, data: Partial<{ password: string; is_active: number; role: UserRole }>) =>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut } from 'lucide-react';
+import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut, UserCircle2, ChevronDown, ChevronUp, Pencil } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
+import { getMyProfile } from '../api';
+import type { UserProfile } from '../types';
+import ProfileEditModal from './ProfileEditModal';
 
 type Theme = 'dark' | 'light' | 'purple' | 'rainbow' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'indigo' | 'glass-light' | 'glass-rich';
 
@@ -66,6 +69,28 @@ export default function Layout() {
   );
   const isGlassTheme = theme === 'glass-light' || theme === 'glass-rich';
 
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [accountOpen, setAccountOpen] = useState(false);
+  const [showEditProfile, setShowEditProfile] = useState(false);
+  const accountRef = useRef<HTMLDivElement>(null);
+
+  const loadProfile = useCallback(() => {
+    getMyProfile().then(setProfile).catch(() => setProfile(null));
+  }, []);
+
+  useEffect(() => { loadProfile(); }, [loadProfile]);
+
+  useEffect(() => {
+    if (!accountOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (accountRef.current && !accountRef.current.contains(e.target as Node)) {
+        setAccountOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [accountOpen]);
+
   const handleLogout = async () => {
     await logout();
     navigate('/login', { replace: true });
@@ -75,6 +100,8 @@ export default function Layout() {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('book_app_theme', theme);
   }, [theme]);
+
+  const displayName = profile?.screen_name || user?.username || '';
 
   return (
     <div className="layout">
@@ -196,9 +223,16 @@ export default function Layout() {
             <BookMarked />
             Series
           </NavLink>
+          <NavLink
+            to="/users"
+            className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
+          >
+            <UserCircle2 />
+            Readers
+          </NavLink>
           {user?.role === 'admin' && (
             <NavLink
-              to="/users"
+              to="/admin/users"
               className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
             >
               <Users />
@@ -206,11 +240,36 @@ export default function Layout() {
             </NavLink>
           )}
         </nav>
-        <div className="sidebar__account">
-          <span className="sidebar__account-username">{user?.username}</span>
-          <button className="btn btn--ghost btn--sm btn--icon" title="Log out" onClick={handleLogout}>
-            <LogOut size={14} />
+        <div className="sidebar__account" ref={accountRef}>
+          <button
+            type="button"
+            className="account-menu__trigger"
+            onClick={() => setAccountOpen(o => !o)}
+          >
+            {profile?.avatar_url ? (
+              <img className="avatar avatar--sm" src={profile.avatar_url} alt="" />
+            ) : (
+              <span className="avatar avatar--sm avatar--fallback">{displayName.charAt(0).toUpperCase() || '?'}</span>
+            )}
+            <span className="sidebar__account-username">{displayName}</span>
+            {accountOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
           </button>
+          {accountOpen && (
+            <div className="account-menu">
+              <button
+                type="button"
+                className="account-menu__item"
+                onClick={() => { setAccountOpen(false); setShowEditProfile(true); }}
+              >
+                <Pencil size={14} />
+                Edit profile
+              </button>
+              <button type="button" className="account-menu__item" onClick={handleLogout}>
+                <LogOut size={14} />
+                Log out
+              </button>
+            </div>
+          )}
         </div>
         <div className="sidebar__theme">
           <div className="form-group" style={{ width: '100%' }}>
@@ -234,6 +293,12 @@ export default function Layout() {
       <main className="main-content">
         <Outlet />
       </main>
+      {showEditProfile && (
+        <ProfileEditModal
+          onClose={() => setShowEditProfile(false)}
+          onSaved={() => { setShowEditProfile(false); loadProfile(); }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ProfileEditModal.tsx
+++ b/frontend/src/components/ProfileEditModal.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from 'react';
+import { ImageIcon, X } from 'lucide-react';
+import { getMyProfile, updateMyProfile, getBooks } from '../api';
+import { parseGenres } from '../types';
+import type { Book } from '../types';
+import Modal from './Modal';
+import { useToast } from './Toast';
+
+const MAX_GENRES = 10;
+
+function compressAvatar(file: File): Promise<string> {
+  return new Promise(resolve => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      const MAX_W = 256, MAX_H = 256;
+      const scale = Math.min(MAX_W / img.naturalWidth, MAX_H / img.naturalHeight, 1);
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(img.naturalWidth * scale);
+      canvas.height = Math.round(img.naturalHeight * scale);
+      canvas.getContext('2d')!.drawImage(img, 0, 0, canvas.width, canvas.height);
+      URL.revokeObjectURL(url);
+      resolve(canvas.toDataURL('image/jpeg', 0.85));
+    };
+    img.src = url;
+  });
+}
+
+interface Props {
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function ProfileEditModal({ onClose, onSaved }: Props) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const [screenName, setScreenName] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState('');
+  const [genreChoices, setGenreChoices] = useState<string[]>([]);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [books, setBooks] = useState<Book[]>([]);
+  const [favoriteBookId, setFavoriteBookId] = useState<number | ''>('');
+
+  useEffect(() => {
+    Promise.all([getMyProfile(), getBooks()])
+      .then(([profile, myBooks]) => {
+        setScreenName(profile.screen_name || '');
+        setAvatarUrl(profile.avatar_url || '');
+        setSelectedGenres(profile.favorite_genres || []);
+        setFavoriteBookId(profile.favorite_book?.id ?? '');
+        setBooks(myBooks);
+        const fromBooks = myBooks.flatMap(b => parseGenres(b));
+        const union = Array.from(new Set([...fromBooks, ...(profile.favorite_genres || [])])).sort();
+        setGenreChoices(union);
+      })
+      .catch(() => setError('Failed to load profile.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggleGenre = (g: string) => {
+    setSelectedGenres(list => {
+      if (list.includes(g)) return list.filter(x => x !== g);
+      if (list.length >= MAX_GENRES) return list;
+      return [...list, g];
+    });
+  };
+
+  const handlePaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (!file) return;
+        const dataUrl = await compressAvatar(file);
+        setAvatarUrl(dataUrl);
+        return;
+      }
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      await updateMyProfile({
+        screen_name: screenName.trim() || null,
+        avatar_url: avatarUrl.trim() || null,
+        favorite_genres: selectedGenres,
+        favorite_book_id: favoriteBookId === '' ? null : Number(favoriteBookId),
+      });
+      toast('success', 'Profile updated.');
+      onSaved();
+    } catch (err: any) {
+      const msg = err.response?.data?.error || 'Failed to update profile.';
+      setError(msg);
+      toast('error', msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasAvatar = avatarUrl.trim() !== '';
+
+  return (
+    <Modal
+      title="Edit profile"
+      onClose={onClose}
+      size="md"
+      footer={
+        <>
+          <button className="btn btn--secondary" onClick={onClose}>Cancel</button>
+          <button className="btn btn--primary" onClick={handleSave} disabled={saving || loading}>
+            {saving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </>
+      }
+    >
+      {loading ? (
+        <div className="skeleton skeleton--row" />
+      ) : (
+        <div>
+          {error && <p className="form-error">{error}</p>}
+
+          <div className="form-group">
+            <label className="form-label">Screen name</label>
+            <input
+              className="form-input"
+              value={screenName}
+              onChange={e => setScreenName(e.target.value.slice(0, 40))}
+              placeholder="Shown to other readers"
+              maxLength={40}
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Avatar</label>
+            <div className="cover-picker" onPaste={handlePaste} tabIndex={0}>
+              <div className="cover-picker__zone cover-picker__zone--avatar">
+                {hasAvatar ? (
+                  <>
+                    <img className="cover-picker__img" src={avatarUrl} alt="Avatar preview" onError={() => setAvatarUrl('')} />
+                    <button type="button" className="cover-picker__clear" onClick={() => setAvatarUrl('')} title="Remove avatar">
+                      <X size={12} />
+                    </button>
+                  </>
+                ) : (
+                  <div className="cover-picker__placeholder">
+                    <ImageIcon size={24} />
+                    <span>Ctrl+V to paste image</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Favorite genres</label>
+            <div className="chip-picker">
+              {genreChoices.length === 0 && <span className="page-subtitle">Add genres to your books to pick favorites.</span>}
+              {genreChoices.map(g => (
+                <button
+                  type="button"
+                  key={g}
+                  className={`chip-picker__chip${selectedGenres.includes(g) ? ' chip-picker__chip--active' : ''}`}
+                  onClick={() => toggleGenre(g)}
+                  disabled={!selectedGenres.includes(g) && selectedGenres.length >= MAX_GENRES}
+                >
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Favorite book</label>
+            <select
+              className="form-select"
+              value={favoriteBookId}
+              onChange={e => setFavoriteBookId(e.target.value === '' ? '' : Number(e.target.value))}
+            >
+              <option value="">None</option>
+              {books.map(b => (
+                <option key={b.id} value={b.id}>{b.title}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/ProfileEditModal.tsx
+++ b/frontend/src/components/ProfileEditModal.tsx
@@ -9,9 +9,13 @@ import { useToast } from './Toast';
 const MAX_GENRES = 10;
 
 function compressAvatar(file: File): Promise<string> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     const img = new Image();
     const url = URL.createObjectURL(file);
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Could not read image'));
+    };
     img.onload = () => {
       const MAX_W = 256, MAX_H = 256;
       const scale = Math.min(MAX_W / img.naturalWidth, MAX_H / img.naturalHeight, 1);
@@ -76,8 +80,12 @@ export default function ProfileEditModal({ onClose, onSaved }: Props) {
         e.preventDefault();
         const file = item.getAsFile();
         if (!file) return;
-        const dataUrl = await compressAvatar(file);
-        setAvatarUrl(dataUrl);
+        try {
+          const dataUrl = await compressAvatar(file);
+          setAvatarUrl(dataUrl);
+        } catch {
+          toast('error', 'Could not read pasted image');
+        }
         return;
       }
     }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { BookOpen, Pencil, UserX } from 'lucide-react';
+import { getUserProfile } from '../api';
+import type { UserProfile } from '../types';
+import { useAuth } from '../context/AuthContext';
+import ProfileEditModal from '../components/ProfileEditModal';
+
+export default function ProfilePage() {
+  const { id } = useParams<{ id: string }>();
+  const { user: me } = useAuth();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+
+  const load = useCallback(() => {
+    if (!id) return;
+    setLoading(true);
+    setNotFound(false);
+    getUserProfile(Number(id))
+      .then(setProfile)
+      .catch((err: any) => {
+        if (err.response?.status === 404) setNotFound(true);
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="page">
+        <div className="skeleton skeleton--row" style={{ height: 140 }} />
+      </div>
+    );
+  }
+
+  if (notFound || !profile) {
+    return (
+      <div className="page">
+        <div className="empty-state">
+          <UserX size={40} />
+          <p>This reader could not be found.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const displayName = profile.screen_name || profile.username;
+  const isSelf = me?.id === profile.id;
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div className="profile-header">
+          {profile.avatar_url ? (
+            <img className="avatar avatar--xl" src={profile.avatar_url} alt="" />
+          ) : (
+            <span className="avatar avatar--xl avatar--fallback">{displayName.charAt(0).toUpperCase()}</span>
+          )}
+          <div>
+            <h1>{displayName}</h1>
+          </div>
+        </div>
+        {isSelf && (
+          <div className="page-header__actions">
+            <button className="btn btn--secondary" onClick={() => setShowEdit(true)}>
+              <Pencil size={14} />
+              Edit profile
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Favorite genres</label>
+        {profile.favorite_genres.length === 0 ? (
+          <p className="page-subtitle">No favorite genres yet.</p>
+        ) : (
+          <div className="chip-picker">
+            {profile.favorite_genres.map(g => (
+              <span key={g} className="tag">{g}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Favorite book</label>
+        {profile.favorite_book ? (
+          <Link to={`/books/${profile.favorite_book.id}`} className="book-card" style={{ maxWidth: 220 }}>
+            <div className="book-card__cover">
+              {profile.favorite_book.cover_url ? (
+                <img src={profile.favorite_book.cover_url} alt={profile.favorite_book.title} />
+              ) : (
+                <BookOpen size={32} />
+              )}
+            </div>
+            <div className="book-card__body">
+              <div className="book-card__title">{profile.favorite_book.title}</div>
+              {profile.favorite_book.author && <div className="book-card__author">{profile.favorite_book.author}</div>}
+            </div>
+          </Link>
+        ) : (
+          <p className="page-subtitle">No favorite book set.</p>
+        )}
+      </div>
+
+      {showEdit && (
+        <ProfileEditModal
+          onClose={() => setShowEdit(false)}
+          onSaved={() => { setShowEdit(false); load(); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ReadersPage.tsx
+++ b/frontend/src/pages/ReadersPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { Users } from 'lucide-react';
+import { getUserProfiles } from '../api';
+import type { UserSummary } from '../types';
+import { useToast } from '../components/Toast';
+
+export default function ReadersPage() {
+  const { toast } = useToast();
+  const [readers, setReaders] = useState<UserSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    getUserProfiles()
+      .then(setReaders)
+      .catch(() => toast('error', 'Failed to load readers.'))
+      .finally(() => setLoading(false));
+  }, [toast]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h1>Readers</h1>
+          <p className="page-subtitle">{readers.length} reader{readers.length !== 1 ? 's' : ''}</p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {[1, 2, 3].map(i => (
+            <div key={i} className="skeleton skeleton--row" />
+          ))}
+        </div>
+      ) : readers.length === 0 ? (
+        <div className="empty-state">
+          <Users size={40} />
+          <p>No other readers yet.</p>
+        </div>
+      ) : (
+        <div className="reader-grid">
+          {readers.map(r => (
+            <Link key={r.id} to={`/users/${r.id}`} className="reader-card">
+              {r.avatar_url ? (
+                <img className="avatar avatar--lg" src={r.avatar_url} alt="" />
+              ) : (
+                <span className="avatar avatar--lg avatar--fallback">{r.screen_name.charAt(0).toUpperCase()}</span>
+              )}
+              <span className="reader-card__name">{r.screen_name}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -51,10 +51,7 @@
 }
 
 .sidebar__account {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: $space-2;
+  position: relative;
   padding: $space-3 $space-4;
   border-top: 1px solid $border;
 
@@ -62,7 +59,62 @@
     font-size: 0.8125rem;
     font-weight: 500;
     color: $text-2;
+    flex: 1;
+    text-align: left;
     @include truncate;
+  }
+}
+
+// ── Account Menu (sidebar avatar dropdown) ─────────────────────────────────
+.account-menu__trigger {
+  display: flex;
+  align-items: center;
+  gap: $space-2;
+  width: 100%;
+  padding: $space-1 + 2px;
+  border-radius: $radius;
+  color: $text-2;
+  transition: background $transition;
+
+  &:hover {
+    background: $bg-elevated;
+    backdrop-filter: var(--glass-blur);
+  }
+
+  svg { flex-shrink: 0; opacity: 0.6; }
+}
+
+.account-menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: $space-4;
+  right: $space-4;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: $space-1 + 2px;
+  background: $bg-card;
+  border: var(--glass-border, 1px solid $border);
+  border-radius: $radius;
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow, 0 8px 24px rgba(0, 0, 0, 0.4));
+  z-index: 10;
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: $space-2;
+    padding: $space-2 $space-3;
+    border-radius: $radius-sm;
+    font-size: 0.8125rem;
+    color: $text-2;
+    text-align: left;
+    transition: background $transition, color $transition;
+
+    &:hover {
+      background: $bg-elevated;
+      color: $text-1;
+    }
   }
 }
 

--- a/frontend/src/styles/_profile.scss
+++ b/frontend/src/styles/_profile.scss
@@ -1,0 +1,111 @@
+@use 'variables' as *;
+
+// ── Avatar ────────────────────────────────────────────────────────────────
+.avatar {
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+
+  &--sm { width: 24px; height: 24px; font-size: 0.7rem; }
+  &--lg { width: 56px; height: 56px; font-size: 1.3rem; }
+  &--xl { width: 80px; height: 80px; font-size: 1.8rem; }
+
+  &--fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $bg-elevated;
+    color: $text-2;
+    font-weight: 700;
+    border: var(--glass-border, 1px solid $border);
+    backdrop-filter: var(--glass-blur);
+  }
+}
+
+// ── Readers Directory ────────────────────────────────────────────────────
+.reader-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: $space-4;
+}
+
+.reader-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $space-2;
+  padding: $space-4;
+  background: $bg-card;
+  border: var(--glass-border, 1px solid $border);
+  border-radius: $radius-lg;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  transition: transform $transition, border-color $transition, box-shadow $transition;
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-shadow, none);
+
+  &:hover {
+    transform: translateY(-3px);
+    border-color: $border-light;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  &__name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: $text-1;
+    @include truncate;
+    max-width: 100%;
+  }
+}
+
+// ── Profile Page ─────────────────────────────────────────────────────────
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: $space-4;
+}
+
+// ── Chip Picker (favorite genres) ────────────────────────────────────────
+.chip-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-2;
+
+  &__chip {
+    padding: $space-1 + 2px $space-3;
+    background: $bg-elevated;
+    border: 1px solid $border;
+    border-radius: 100px;
+    font-size: 0.8rem;
+    color: $text-2;
+    transition: background $transition, color $transition, border-color $transition;
+    backdrop-filter: var(--glass-blur);
+
+    &:hover:not(:disabled) {
+      border-color: $accent;
+      color: $text-1;
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    &--active {
+      background: $accent;
+      border-color: $accent;
+      color: #fff;
+    }
+  }
+}
+
+// ── Avatar picker (reuses .cover-picker) ─────────────────────────────────
+.cover-picker__zone--avatar {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+
+  .cover-picker__img { object-fit: cover; }
+}

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -3,4 +3,5 @@
 @use 'base';
 @use 'layout';
 @use 'components';
+@use 'profile';
 @use 'rainbow';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,28 @@ export interface ManagedUser {
   created_at: string;
 }
 
+export interface UserSummary {
+  id: number;
+  screen_name: string;
+  avatar_url: string | null;
+}
+
+export interface FavoriteBook {
+  id: number;
+  title: string;
+  author: string | null;
+  cover_url: string | null;
+}
+
+export interface UserProfile {
+  id: number;
+  username: string;
+  screen_name: string | null;
+  avatar_url: string | null;
+  favorite_genres: string[];
+  favorite_book: FavoriteBook | null;
+}
+
 export interface Book {
   id: number;
   title: string;


### PR DESCRIPTION
## Summary
- Public user profiles visible to all logged-in users, editable by owner only
- New `users` columns via migrations array: `screen_name`, `avatar_url` (data URL, 256×256 client-side downscale), `favorite_genres` (JSON text), `favorite_book_id` (FK, `ON DELETE SET NULL`, ownership-validated)
- Routes: `GET/PUT /api/users/me/profile`, `GET /api/users/:id/profile` (404 for inactive), `GET /api/users` now the public directory for all logged-in users; admin management list moved to `GET /api/users/admin`, admin page to `/admin/users`
- Frontend: Readers directory (`/users`), profile page (`/users/:id`), profile edit modal (clipboard avatar paste, genre chips from own library, favorite book select), Layout account dropdown with avatar
- Design doc: `docs/plans/2026-07-11-user-profiles-design.md`

## Notes
- `express.json` limit raised to 1mb for avatar data URLs; backend rejects avatars > 500KB
- Public payloads never include `password_hash`, `role`, `is_active`
- Independent review pass done; both findings fixed in f909594

🤖 Generated with [Claude Code](https://claude.com/claude-code)