### PR TITLE
chore: deploy user-profiles image

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:3f072d6827da3fefe4ac29d51c9962ecc97a654e8527f6edb930bfa0ac52b6cb
+          image: ghcr.io/mzakhar/vs-book-app@sha256:6a52af3d6bc34f44a9f21416157af916d4fbfd77aabe72b206d0b7754b280915
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pin deployment to the PR #21 build: `ghcr.io/mzakhar/vs-book-app@sha256:6a52af3d...` (tag `sha-40c8ce8`, verified equal to `:main`). Flux reconciles `k8s/base` on merge — no version tag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)