### PR TITLE
fix: add-to-wishlist saved nothing — prefilled form mistaken for edit

### DIFF
--- a/frontend/src/components/BookForm.tsx
+++ b/frontend/src/components/BookForm.tsx
@@ -165,7 +165,7 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
         page_count:      form.page_count !== '' ? Number(form.page_count) : undefined,
         description:     form.description.trim() || undefined,
       };
-      const book = existing
+      const book = existing?.id != null
         ? await updateBook(existing.id, payload)
         : await createBook(payload);
       onSave(book);
@@ -361,7 +361,7 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
       <div className="modal__footer" style={{ padding: 0, border: 'none', marginTop: '8px' }}>
         <button type="button" className="btn btn--secondary" onClick={onCancel}>Cancel</button>
         <button type="submit" className="btn btn--primary" disabled={saving}>
-          {saving ? 'Saving…' : existing ? 'Save Changes' : 'Add Book'}
+          {saving ? 'Saving…' : existing?.id != null ? 'Save Changes' : 'Add Book'}
         </button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- `Wishlist` add modal passes `existing={ status: 'wishlist' }` (no `id`) to BookForm just to prefill the status dropdown
- BookForm gated create-vs-update on `existing`'s truthiness, so it rendered **Save Changes** and submitted `PUT /api/books/undefined`, which 404s — book never created
- Gate edit mode on `existing?.id != null` for both the submit path and the button label

Fixes #20

## Test plan
- `npm run build` (frontend) passes
- Wishlist → Add to Wishlist now shows **Add Book** and POSTs to create
- Editing an existing book still PUTs with its id

🤖 Generated with [Claude Code](https://claude.com/claude-code)