### PR TITLE
chore: deploy wishlist-fix image (v1.0.0)

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:6a52af3d6bc34f44a9f21416157af916d4fbfd77aabe72b206d0b7754b280915
+          image: ghcr.io/mzakhar/vs-book-app@sha256:a955700f69eb17a8d1025304224015c1dc671a72b77cafeaefafffbd8a51acb5
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pins deployment to v1.0.0 image digest (sha256:a955700f…) containing the #20 wishlist fix (#25). Flux will reconcile the rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)