### PR TITLE
chore: deploy feedback image (v1.1.0)

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:a955700f69eb17a8d1025304224015c1dc671a72b77cafeaefafffbd8a51acb5
+          image: ghcr.io/mzakhar/vs-book-app@sha256:4c5ecfdfcbb88b6897e2d0e2f2c7d847808cbb92379cf3dab1d8d2a37b69a79f
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
@@ -37,6 +37,15 @@ spec:
                 secretKeyRef:
                   name: vs-book-app-admin
                   key: ADMIN_PASSWORD
+                  optional: true
+            - name: GITHUB_REPO
+              value: mzakhar/vs-book-app
+            # In-app feedback → GitHub issues; endpoint returns 503 while unset.
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vs-book-app-github
+                  key: GITHUB_TOKEN
                   optional: true
           ports:
             - containerPort: 3000

--- a/k8s/base/github-secret.example.yaml
+++ b/k8s/base/github-secret.example.yaml
@@ -1,0 +1,17 @@
+# Example only — NOT included in kustomization.yaml and must never be committed
+# with real values. Create the real secret out-of-band:
+#
+#   kubectl -n vs-book-app create secret generic vs-book-app-github \
+#     --from-literal=GITHUB_TOKEN=<fine-grained PAT, Issues read+write, this repo only>
+#
+# Used by the in-app feedback feature to create GitHub issues. The feedback
+# endpoint returns 503 while the secret is absent; the rest of the app is
+# unaffected. Rotate by recreating the secret and restarting the deployment.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vs-book-app-github
+  namespace: vs-book-app
+type: Opaque
+stringData:
+  GITHUB_TOKEN: change-me


### PR DESCRIPTION
Bumps image to the v1.1.0 digest (feedback feature, PR #27) and wires `GITHUB_TOKEN` from new optional secret `vs-book-app-github` + `GITHUB_REPO` env.

Secret is created out-of-band on themachine (see `k8s/base/github-secret.example.yaml`); rollout does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)