### PR TITLE
feat: phone/tablet friendly UI

### DIFF
--- a/frontend/src/components/BookForm.tsx
+++ b/frontend/src/components/BookForm.tsx
@@ -1,9 +1,10 @@
 import { useState, FormEvent, useRef, useEffect } from 'react';
-import { ImageIcon, X, Search, Loader } from 'lucide-react';
+import { ImageIcon, Search, Loader } from 'lucide-react';
 import { createBook, updateBook } from '../api';
 import type { Book, BookStatus } from '../types';
 import { searchOpenLibrary, fetchWorkDetails, fetchEditions, normalizeAutoFill } from '../api/openLibrary';
 import type { OLSearchResult } from '../api/openLibrary';
+import ImagePicker from './ImagePicker';
 
 const STATUSES: { value: BookStatus; label: string }[] = [
   { value: 'unread', label: 'Unread' },
@@ -132,21 +133,6 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
     }
   };
 
-  const handlePaste = async (e: React.ClipboardEvent<HTMLFormElement>) => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
-    for (const item of Array.from(items)) {
-      if (item.type.startsWith('image/')) {
-        e.preventDefault();
-        const file = item.getAsFile();
-        if (!file) return;
-        const dataUrl = await compressImage(file);
-        set('cover_url', dataUrl);
-        return;
-      }
-    }
-  };
-
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!form.title.trim()) { setError('Title is required.'); return; }
@@ -175,10 +161,8 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
     }
   };
 
-  const hasCover = form.cover_url.trim() !== '';
-
   return (
-    <form onSubmit={handleSubmit} onPaste={handlePaste}>
+    <form onSubmit={handleSubmit}>
       {error && <p className="form-error">{error}</p>}
 
       {/* OL Search */}
@@ -278,39 +262,13 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
         {/* Cover picker */}
         <div className="form-group" style={{ gridColumn: '1 / -1' }}>
           <label className="form-label">Cover Image</label>
-          <div className="cover-picker">
-            <div className="cover-picker__zone">
-              {hasCover ? (
-                <>
-                  <img
-                    className="cover-picker__img"
-                    src={form.cover_url}
-                    alt="Cover preview"
-                    onError={() => set('cover_url', '')}
-                  />
-                  <button
-                    type="button"
-                    className="cover-picker__clear"
-                    onClick={() => set('cover_url', '')}
-                    title="Remove cover"
-                  >
-                    <X size={12} />
-                  </button>
-                </>
-              ) : (
-                <div className="cover-picker__placeholder">
-                  <ImageIcon size={28} />
-                  <span>Ctrl+V to paste image</span>
-                </div>
-              )}
-            </div>
-            <input
-              className="form-input cover-picker__url"
-              value={hasCover && form.cover_url.startsWith('data:') ? '' : form.cover_url}
-              onChange={e => set('cover_url', e.target.value)}
-              placeholder="…or paste / type an image URL"
-            />
-          </div>
+          <ImagePicker
+            value={form.cover_url}
+            onChange={url => set('cover_url', url)}
+            compress={compressImage}
+            variant="cover"
+            alt="Cover preview"
+          />
         </div>
 
         {/* Series fields */}

--- a/frontend/src/components/ImagePicker.tsx
+++ b/frontend/src/components/ImagePicker.tsx
@@ -1,0 +1,106 @@
+import { useRef, useState } from 'react';
+import { ImageIcon, X } from 'lucide-react';
+
+interface Props {
+  value: string;
+  onChange: (dataUrl: string) => void;
+  compress: (file: File) => Promise<string>;
+  variant?: 'cover' | 'avatar';
+  alt: string;
+}
+
+export default function ImagePicker({ value, onChange, compress, variant, alt }: Props) {
+  const [error, setError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const hasImage = value.trim() !== '';
+
+  const handleFile = async (file: File) => {
+    try {
+      const dataUrl = await compress(file);
+      setError('');
+      onChange(dataUrl);
+    } catch {
+      setError('Could not read image.');
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    e.target.value = '';
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (file) handleFile(file);
+        return;
+      }
+    }
+  };
+
+  const handleZoneKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setError('');
+    onChange('');
+  };
+
+  return (
+    <div className="cover-picker">
+      <div
+        className={`cover-picker__zone${variant === 'avatar' ? ' cover-picker__zone--avatar' : ''}`}
+        tabIndex={0}
+        role="button"
+        aria-label="Choose image"
+        onClick={() => fileInputRef.current?.click()}
+        onPaste={handlePaste}
+        onKeyDown={handleZoneKeyDown}
+      >
+        {hasImage ? (
+          <>
+            <img className="cover-picker__img" src={value} alt={alt} onError={() => onChange('')} />
+            <button
+              type="button"
+              className="cover-picker__clear"
+              onClick={handleClear}
+              title="Remove image"
+            >
+              <X size={12} />
+            </button>
+          </>
+        ) : (
+          <div className="cover-picker__placeholder">
+            <ImageIcon size={variant === 'avatar' ? 24 : 28} />
+            <span>Tap to choose an image (or Ctrl+V)</span>
+          </div>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+        />
+      </div>
+      <input
+        className="form-input cover-picker__url"
+        value={/^https?:\/\//i.test(value) ? value : ''}
+        onChange={e => onChange(e.target.value)}
+        placeholder="…or paste an image URL"
+      />
+      {error && <p className="form-error">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileEditModal.tsx
+++ b/frontend/src/components/ProfileEditModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { ImageIcon, X } from 'lucide-react';
 import { getMyProfile, updateMyProfile, getBooks } from '../api';
 import { parseGenres } from '../types';
 import type { Book } from '../types';
 import Modal from './Modal';
+import ImagePicker from './ImagePicker';
 import { useToast } from './Toast';
 
 const MAX_GENRES = 10;
@@ -72,25 +72,6 @@ export default function ProfileEditModal({ onClose, onSaved }: Props) {
     });
   };
 
-  const handlePaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
-    for (const item of Array.from(items)) {
-      if (item.type.startsWith('image/')) {
-        e.preventDefault();
-        const file = item.getAsFile();
-        if (!file) return;
-        try {
-          const dataUrl = await compressAvatar(file);
-          setAvatarUrl(dataUrl);
-        } catch {
-          toast('error', 'Could not read pasted image');
-        }
-        return;
-      }
-    }
-  };
-
   const handleSave = async () => {
     setSaving(true);
     setError('');
@@ -111,8 +92,6 @@ export default function ProfileEditModal({ onClose, onSaved }: Props) {
       setSaving(false);
     }
   };
-
-  const hasAvatar = avatarUrl.trim() !== '';
 
   return (
     <Modal
@@ -147,23 +126,13 @@ export default function ProfileEditModal({ onClose, onSaved }: Props) {
 
           <div className="form-group">
             <label className="form-label">Avatar</label>
-            <div className="cover-picker" onPaste={handlePaste} tabIndex={0}>
-              <div className="cover-picker__zone cover-picker__zone--avatar">
-                {hasAvatar ? (
-                  <>
-                    <img className="cover-picker__img" src={avatarUrl} alt="Avatar preview" onError={() => setAvatarUrl('')} />
-                    <button type="button" className="cover-picker__clear" onClick={() => setAvatarUrl('')} title="Remove avatar">
-                      <X size={12} />
-                    </button>
-                  </>
-                ) : (
-                  <div className="cover-picker__placeholder">
-                    <ImageIcon size={24} />
-                    <span>Ctrl+V to paste image</span>
-                  </div>
-                )}
-              </div>
-            </div>
+            <ImagePicker
+              value={avatarUrl}
+              onChange={setAvatarUrl}
+              compress={compressAvatar}
+              variant="avatar"
+              alt="Avatar preview"
+            />
           </div>
 
           <div className="form-group">

--- a/frontend/src/styles/_base.scss
+++ b/frontend/src/styles/_base.scss
@@ -14,6 +14,10 @@ html {
   --glass-blur: none;
   --glass-border: none;
   --glass-shadow: none;
+
+  @media (max-width: 768px) {
+    font-size: 16px;
+  }
 }
 
 body {

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -17,7 +17,7 @@
   &--primary {
     background: $accent;
     color: #fff;
-    &:hover { background: $accent-hover; }
+    &:hover, &:focus-visible { background: $accent-hover; }
   }
 
   &--secondary {
@@ -25,19 +25,19 @@
     color: $text-1;
     border: 1px solid $border-light;
     backdrop-filter: var(--glass-blur);
-    &:hover { background: $bg-hover; border-color: var(--btn-secondary-hover-border); }
+    &:hover, &:focus-visible { background: $bg-hover; border-color: var(--btn-secondary-hover-border); }
   }
 
   &--ghost {
     color: $text-2;
-    &:hover { background: $bg-elevated; color: $text-1; backdrop-filter: var(--glass-blur); }
+    &:hover, &:focus-visible { background: $bg-elevated; color: $text-1; backdrop-filter: var(--glass-blur); }
   }
 
   &--danger {
     background: $danger-bg;
     color: $danger;
     border: 1px solid var(--danger-border);
-    &:hover { background: var(--danger-hover-bg); }
+    &:hover, &:focus-visible { background: var(--danger-hover-bg); }
   }
 
   &--sm {
@@ -90,6 +90,11 @@
   }
 
   option { background: $bg-elevated; }
+
+  // 16px kills iOS Safari's auto-zoom-on-focus behavior
+  @media (max-width: 768px) {
+    font-size: 16px;
+  }
 }
 
 .form-textarea {
@@ -187,6 +192,10 @@
 
     &::placeholder { color: $text-4; }
     &:focus { outline: none; border-color: $border-light; }
+
+    @media (max-width: 768px) {
+      font-size: 16px;
+    }
   }
 }
 
@@ -241,7 +250,12 @@
     color: $text-3;
     border-radius: $radius-sm;
     transition: color $transition, background $transition;
-    &:hover { color: $text-1; background: $bg-elevated; }
+    &:hover, &:focus-visible { color: $text-1; background: $bg-elevated; }
+
+    @media (pointer: coarse) {
+      width: 44px;
+      height: 44px;
+    }
   }
 
   &__body {
@@ -446,7 +460,15 @@
     transition: background $transition, color $transition;
     white-space: nowrap;
 
-    &:hover { color: $text-1; }
+    @media (pointer: coarse) {
+      min-width: 44px;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &:hover, &:focus-visible { color: $text-1; }
 
     &--active {
       background: $bg-card;
@@ -461,6 +483,11 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: $space-4;
+  max-width: 100%;
+
+  @media (max-width: 480px) {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
 
   &__item {
     text-decoration: none;
@@ -535,6 +562,11 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: $space-4;
+  max-width: 100%;
+
+  @media (max-width: 480px) {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
 }
 
 .book-card {
@@ -556,7 +588,9 @@
     transform: translateY(-3px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 
-    .book-card__delete { opacity: 1; }
+    @media (hover: hover) {
+      .book-card__delete { opacity: 1; }
+    }
   }
 
   &__cover {
@@ -614,14 +648,17 @@
     position: absolute;
     top: $space-2;
     right: $space-2;
-    opacity: 0;
     transition: opacity $transition;
     background: $bg-card;
     border: 1px solid $border;
     color: $danger;
     backdrop-filter: var(--glass-blur);
 
-    &:hover { background: $danger-bg; }
+    @media (hover: hover) {
+      opacity: 0;
+    }
+
+    &:hover, &:focus-visible { background: $danger-bg; }
   }
 }
 
@@ -911,7 +948,12 @@
     justify-content: center;
     transition: background $transition;
 
-    &:hover { background: var(--danger); }
+    &:hover, &:focus-visible { background: var(--danger); }
+
+    @media (pointer: coarse) {
+      width: 44px;
+      height: 44px;
+    }
   }
 
   &__url {

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -76,7 +76,7 @@
   color: $text-2;
   transition: background $transition;
 
-  &:hover {
+  &:hover, &:focus-visible {
     background: $bg-elevated;
     backdrop-filter: var(--glass-blur);
   }
@@ -111,7 +111,7 @@
     text-align: left;
     transition: background $transition, color $transition;
 
-    &:hover {
+    &:hover, &:focus-visible {
       background: $bg-elevated;
       color: $text-1;
     }
@@ -149,7 +149,7 @@
     transition: opacity $transition;
   }
 
-  &:hover {
+  &:hover, &:focus-visible {
     color: $text-1;
     background: $bg-elevated;
     backdrop-filter: var(--glass-blur);
@@ -184,6 +184,39 @@
   flex: 1;
   min-height: 100vh;
   overflow-x: hidden;
+}
+
+// ── Small screens: sidebar becomes a horizontal top bar ────────────────────
+@media (max-width: 768px) {
+  .sidebar {
+    position: static;
+    width: 100%;
+    height: auto;
+  }
+
+  .sidebar__brand {
+    padding: $space-3 $space-4;
+  }
+
+  .sidebar__nav {
+    flex-direction: row;
+    overflow-x: auto;
+    padding: $space-2 $space-3;
+    @include scrollbar;
+  }
+
+  .nav-item {
+    flex-shrink: 0;
+  }
+
+  .sidebar__account,
+  .sidebar__theme {
+    flex-shrink: 0;
+  }
+
+  .main-content {
+    margin-left: 0;
+  }
 }
 
 // ── Page ──────────────────────────────────────────────────────────────────

--- a/frontend/src/styles/_profile.scss
+++ b/frontend/src/styles/_profile.scss
@@ -27,6 +27,11 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   gap: $space-4;
+  max-width: 100%;
+
+  @media (max-width: 480px) {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
 }
 
 .reader-card {


### PR DESCRIPTION
Closes #29

## What

Full mobile/tablet pass over the frontend, driven by an audit of touch/responsive gaps.

### Image upload works on touch (the known gap)
New shared `ImagePicker` component, used for both book covers (`BookForm`) and profile avatars (`ProfileEditModal`):
- Tap the picker zone to open the native file chooser (camera/gallery on mobile)
- Desktop clipboard paste (Ctrl+V) still works
- New image-URL text field as a third path
- Keyboard accessible (Enter/Space opens chooser); compress failures show inline error and keep the prior image

### Responsive/touch fixes from the audit
- Sidebar (fixed 200px) collapses to a horizontally scrollable top bar at ≤768px; content gets full width
- Book-card delete button was hover-revealed (invisible on touch) — now always visible on devices without hover, via `@media (hover: hover)`; added `:focus-visible` parity to hover states for keyboard users
- Tap targets ≥44px on coarse pointers: view toggle, modal close, cover-clear button
- Gallery/grid `minmax` values tightened at ≤480px so phones get sensible columns without horizontal scroll
- Inputs 16px on mobile (stops iOS focus auto-zoom); base font 14px → 16px at ≤768px

Viewport meta was already correct; no changes needed there.

## Verification
- `npm run build` (tsc + vite) green
- Independent diff review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)