### PR TITLE
feat: collapsible sidebar, favorite books, crisper goo background (#28)

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -140,6 +140,7 @@ export async function getDb(): Promise<Database> {
     `ALTER TABLE users ADD COLUMN avatar_url TEXT`,
     `ALTER TABLE users ADD COLUMN favorite_genres TEXT`,
     `ALTER TABLE users ADD COLUMN favorite_book_id INTEGER REFERENCES books(id) ON DELETE SET NULL`,
+    `ALTER TABLE books ADD COLUMN is_favorite INTEGER DEFAULT 0`,
   ];
   for (const sql of migrations) {
     try { await _db.run(sql); } catch { /* column already exists */ }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,7 @@ import { getDb } from './database';
 import { requireAuth } from './middleware/auth';
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = Number(process.env.PORT) || 3000;
 const IS_PROD = process.env.NODE_ENV === 'production';
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../../books.db');
 
@@ -57,7 +57,7 @@ app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
 });
 
 getDb().then(() => {
-  app.listen(PORT, () => {
+  app.listen(PORT, '127.0.0.1', () => {
     console.log(`Books API running on http://localhost:${PORT} using DB ${DB_PATH}`);
   });
 }).catch(err => {

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -191,6 +191,17 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   res.json(await db.get(`${SELECT_BOOK} WHERE b.id = ? AND b.user_id = ? ${GROUP_BY_BOOK}`, req.params.id, req.user!.id));
 }));
 
+router.patch('/:id/favorite', asyncHandler(async (req: Request, res: Response) => {
+  const db = await getDb();
+  const existing = await db.get(`SELECT id FROM books WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);
+  if (!existing) return res.status(404).json({ error: 'Book not found' });
+
+  const is_favorite = req.body.is_favorite ? 1 : 0;
+  await db.run(`UPDATE books SET is_favorite=? WHERE id=? AND user_id=?`, is_favorite, req.params.id, req.user!.id);
+
+  res.json(await db.get(`${SELECT_BOOK} WHERE b.id = ? AND b.user_id = ? ${GROUP_BY_BOOK}`, req.params.id, req.user!.id));
+}));
+
 router.delete('/:id', asyncHandler(async (req: Request, res: Response) => {
   const db = await getDb();
   const existing = await db.get(`SELECT id, series_id FROM books WHERE id = ? AND user_id = ?`, req.params.id, req.user!.id);

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -81,6 +81,8 @@ export const updateBook = (id: number, data: Partial<Book> & { series_name?: str
   api.put<Book>(`/books/${id}`, data).then(r => r.data);
 export const deleteBook = (id: number) =>
   api.delete(`/books/${id}`);
+export const toggleFavorite = (id: number, is_favorite: number) =>
+  api.patch<Book>(`/books/${id}/favorite`, { is_favorite }).then(r => r.data);
 export const getStats = () =>
   api.get<BookStats>('/books/stats').then(r => r.data);
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut, UserCircle2, ChevronDown, ChevronUp, Pencil, MessageSquare } from 'lucide-react';
+import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut, UserCircle2, ChevronDown, ChevronUp, Pencil, MessageSquare, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { getMyProfile } from '../api';
 import type { UserProfile } from '../types';
@@ -74,6 +74,7 @@ export default function Layout() {
   const [accountOpen, setAccountOpen] = useState(false);
   const [showEditProfile, setShowEditProfile] = useState(false);
   const accountRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState(() => localStorage.getItem('book_app_sidebar_collapsed') === '1');
 
   const loadProfile = useCallback(() => {
     getMyProfile().then(setProfile).catch(() => setProfile(null));
@@ -102,10 +103,14 @@ export default function Layout() {
     localStorage.setItem('book_app_theme', theme);
   }, [theme]);
 
+  useEffect(() => {
+    localStorage.setItem('book_app_sidebar_collapsed', collapsed ? '1' : '0');
+  }, [collapsed]);
+
   const displayName = profile?.screen_name || user?.username || '';
 
   return (
-    <div className="layout">
+    <div className={`layout${collapsed ? ' layout--sidebar-collapsed' : ''}`}>
       {isGlassTheme && (
         <div className="glass-scene" aria-hidden="true">
           <div className="glass-bg" />
@@ -122,9 +127,7 @@ export default function Layout() {
                     0 0 1 0 0
                     0 0 0 22 -9
                   "
-                  result="goo"
                 />
-                <feBlend in="SourceGraphic" in2="goo" />
               </filter>
             </defs>
           </svg>
@@ -174,7 +177,7 @@ export default function Layout() {
           ))}
         </div>
       )}
-      <aside className="sidebar">
+      <aside className={`sidebar${collapsed ? ' sidebar--collapsed' : ''}`}>
         <div className="sidebar__brand">
           <span className="sidebar__brand-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 141" width="32" height="32">
@@ -193,6 +196,15 @@ export default function Layout() {
             </svg>
           </span>
           <span className="sidebar__brand-title">V&apos;s Books</span>
+          <button
+            type="button"
+            className="sidebar__collapse-btn"
+            onClick={() => setCollapsed(c => !c)}
+            title={collapsed ? 'Expand' : 'Collapse'}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+          </button>
         </div>
         <nav className="sidebar__nav">
           <NavLink
@@ -201,42 +213,42 @@ export default function Layout() {
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <LayoutDashboard />
-            Dashboard
+            <span className="nav-item__label">Dashboard</span>
           </NavLink>
           <NavLink
             to="/library"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <BookOpen />
-            My Library
+            <span className="nav-item__label">My Library</span>
           </NavLink>
           <NavLink
             to="/wishlist"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <Star />
-            Wishlist
+            <span className="nav-item__label">Wishlist</span>
           </NavLink>
           <NavLink
             to="/series"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <BookMarked />
-            Series
+            <span className="nav-item__label">Series</span>
           </NavLink>
           <NavLink
             to="/messages"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <MessageSquare />
-            Messages
+            <span className="nav-item__label">Messages</span>
           </NavLink>
           <NavLink
             to="/users"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
           >
             <UserCircle2 />
-            Readers
+            <span className="nav-item__label">Readers</span>
           </NavLink>
           {user?.role === 'admin' && (
             <NavLink
@@ -244,7 +256,7 @@ export default function Layout() {
               className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
             >
               <Users />
-              Users
+              <span className="nav-item__label">Users</span>
             </NavLink>
           )}
         </nav>

--- a/frontend/src/pages/BookList.tsx
+++ b/frontend/src/pages/BookList.tsx
@@ -169,6 +169,13 @@ export default function BookList() {
                     <span>{book.title}</span>
                   </div>
                 )}
+                <button
+                  className={`book-gallery__favorite btn btn--icon btn--ghost${book.is_favorite ? ' book-gallery__favorite--active' : ''}`}
+                  onClick={e => handleToggleFavorite(e, book)}
+                  title={book.is_favorite ? 'Unfavorite' : 'Favorite'}
+                >
+                  <Heart size={14} fill={book.is_favorite ? 'currentColor' : 'none'} />
+                </button>
               </div>
               <div className="book-gallery__title">{book.title}</div>
             </Link>

--- a/frontend/src/pages/BookList.tsx
+++ b/frontend/src/pages/BookList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { Search, Plus, Trash2, BookOpen, Star, ArrowUpDown } from 'lucide-react';
-import { getBooks, deleteBook } from '../api';
+import { Search, Plus, BookOpen, Star, ArrowUpDown, Heart } from 'lucide-react';
+import { getBooks, toggleFavorite } from '../api';
 import { Book, BookStatus, parseGenres } from '../types';
 import Modal from '../components/Modal';
 import BookForm from '../components/BookForm';
@@ -74,16 +74,14 @@ export default function BookList() {
     return () => clearTimeout(t);
   }, [search, load]);
 
-  const handleDelete = async (e: React.MouseEvent, book: Book) => {
+  const handleToggleFavorite = async (e: React.MouseEvent, book: Book) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!confirm(`Delete "${book.title}"? This cannot be undone.`)) return;
     try {
-      await deleteBook(book.id);
-      setBooks(bs => bs.filter(b => b.id !== book.id));
-      toast('success', 'Book deleted.');
+      const updated = await toggleFavorite(book.id, book.is_favorite ? 0 : 1);
+      setBooks(bs => bs.map(b => b.id === book.id ? updated : b));
     } catch {
-      toast('error', 'Failed to delete book.');
+      toast('error', 'Failed to update favorite.');
     }
   };
 
@@ -199,11 +197,11 @@ export default function BookList() {
                 <StarRating rating={book.rating} />
               </div>
               <button
-                className="book-card__delete btn btn--icon btn--ghost"
-                onClick={e => handleDelete(e, book)}
-                title="Delete book"
+                className={`book-card__favorite btn btn--icon btn--ghost${book.is_favorite ? ' book-card__favorite--active' : ''}`}
+                onClick={e => handleToggleFavorite(e, book)}
+                title={book.is_favorite ? 'Unfavorite' : 'Favorite'}
               >
-                <Trash2 size={14} />
+                <Heart size={14} fill={book.is_favorite ? 'currentColor' : 'none'} />
               </button>
             </Link>
           ))}

--- a/frontend/src/styles/_base.scss
+++ b/frontend/src/styles/_base.scss
@@ -63,7 +63,6 @@ body {
   position: absolute;
   border-radius: 999px;
   opacity: 0.9;
-  filter: blur(14px);
 
   &--a {
     background: radial-gradient(circle at 35% 30%, var(--blob-a-light) 0%, var(--blob-a-mid) 48%, var(--blob-a-dark) 100%);
@@ -120,7 +119,6 @@ html[data-theme="glass-light"] {
 
   .glass-circle {
     opacity: 0.82;
-    filter: blur(10px);
   }
 }
 

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -503,6 +503,7 @@
   }
 
   &__cover-wrap {
+    position: relative;
     aspect-ratio: 2 / 3;
     border-radius: $radius;
     overflow: hidden;
@@ -513,6 +514,33 @@
     align-items: center;
     justify-content: center;
     backdrop-filter: var(--glass-blur);
+  }
+
+  &__favorite {
+    position: absolute;
+    top: $space-2;
+    right: $space-2;
+    z-index: 1;
+    background: $bg-card;
+    border: 1px solid $border;
+    color: $text-3;
+    backdrop-filter: var(--glass-blur);
+    transition: opacity $transition, color $transition;
+
+    @media (hover: hover) {
+      opacity: 0;
+    }
+
+    &:hover, &:focus-visible { background: $danger-bg; color: $danger; }
+
+    &--active {
+      color: $danger;
+      opacity: 1;
+    }
+  }
+
+  &__item:hover &__favorite {
+    opacity: 1;
   }
 
   &__cover {

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -589,7 +589,7 @@
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 
     @media (hover: hover) {
-      .book-card__delete { opacity: 1; }
+      .book-card__favorite { opacity: 1; }
     }
   }
 
@@ -644,21 +644,26 @@
     margin-top: auto;
   }
 
-  &__delete {
+  &__favorite {
     position: absolute;
     top: $space-2;
     right: $space-2;
-    transition: opacity $transition;
+    transition: opacity $transition, color $transition;
     background: $bg-card;
     border: 1px solid $border;
-    color: $danger;
+    color: $text-3;
     backdrop-filter: var(--glass-blur);
 
     @media (hover: hover) {
       opacity: 0;
     }
 
-    &:hover, &:focus-visible { background: $danger-bg; }
+    &:hover, &:focus-visible { background: $danger-bg; color: $danger; }
+
+    &--active {
+      color: $danger;
+      opacity: 1;
+    }
   }
 }
 

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -1,5 +1,7 @@
 @use 'variables' as *;
 
+$sidebar-collapsed-width: 68px;
+
 .layout {
   display: flex;
   min-height: 100vh;
@@ -39,6 +41,24 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     color: $text-1;
+    flex: 1;
+  }
+}
+
+.sidebar__collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: $radius-sm;
+  color: $text-3;
+  transition: color $transition, background $transition;
+
+  &:hover, &:focus-visible {
+    color: $text-1;
+    background: $bg-elevated;
   }
 }
 
@@ -186,6 +206,59 @@
   overflow-x: hidden;
 }
 
+// ── Collapsed sidebar (icons-only rail) ─────────────────────────────────────
+.sidebar--collapsed {
+  width: $sidebar-collapsed-width;
+
+  .sidebar__brand {
+    justify-content: center;
+    padding: $space-6 $space-2;
+  }
+
+  .sidebar__brand-title {
+    display: none;
+  }
+
+  .sidebar__nav {
+    padding: $space-4 $space-2;
+  }
+
+  .nav-item {
+    justify-content: center;
+    padding: $space-2 + 2px;
+
+    &__label {
+      display: none;
+    }
+  }
+
+  .sidebar__account {
+    padding: $space-3 $space-2;
+  }
+
+  .account-menu__trigger {
+    justify-content: center;
+  }
+
+  .sidebar__account-username,
+  .account-menu__trigger > svg:last-child {
+    display: none;
+  }
+
+  .sidebar__theme {
+    padding: $space-3 $space-2 $space-5;
+
+    .form-group > div:first-child,
+    .form-select {
+      display: none;
+    }
+  }
+}
+
+.layout--sidebar-collapsed .main-content {
+  margin-left: $sidebar-collapsed-width;
+}
+
 // ── Small screens: sidebar becomes a horizontal top bar ────────────────────
 @media (max-width: 768px) {
   .sidebar {
@@ -214,7 +287,12 @@
     flex-shrink: 0;
   }
 
-  .main-content {
+  .sidebar--collapsed {
+    width: 100%;
+  }
+
+  .main-content,
+  .layout--sidebar-collapsed .main-content {
     margin-left: 0;
   }
 }

--- a/frontend/src/styles/_themes.scss
+++ b/frontend/src/styles/_themes.scss
@@ -726,13 +726,13 @@
     linear-gradient(135deg, #150f2f 0%, #2c144d 26%, #12386a 58%, #111b3d 100%);
   --blob-a-light: #ff6ab9;
   --blob-a-mid: #df3cff;
-  --blob-a-dark: #7b3cff;
+  --blob-a-dark: #1e0433;
   --blob-b-light: #67f7ff;
   --blob-b-mid: #11d5ff;
-  --blob-b-dark: #1868ff;
+  --blob-b-dark: #00151e;
   --blob-c-light: #ffd26f;
   --blob-c-mid: #ff914d;
-  --blob-c-dark: #ff5d7c;
+  --blob-c-dark: #1a0800;
 
   --glass-blur: blur(24px);
   --glass-border: 1px solid rgba(255, 255, 255, 0.14);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -59,6 +59,7 @@ export interface Book {
   series_name?: string | null;
   page_count?: number | null;
   description?: string | null;
+  is_favorite?: number;
 }
 
 export interface BookStats {


### PR DESCRIPTION
Closes #28.

## Changes
- **Collapsible sidebar** — toggle to an icons-only rail; state persists in `localStorage` (`book_app_sidebar_collapsed`).
- **Favorite books** — heart toggle on library cards (delete moved to the book detail screen). New `PATCH /api/books/:id/favorite` endpoint + `is_favorite` column (migration).
- **Goo background** — glass goo balls now read as distinct connected metaballs: removed per-circle `blur`, the trailing `feBlend` that re-drew hard circle edges, and the bright rim gradient stops (near-black hue-matched rims dissolve into the background with color bleed at merges). Matches the session-runner look. `glass-light` left as-is (saturated rims read soft on a light background).
- **Backend** — bind `listen` to `127.0.0.1` explicitly (avoids shadowing other localhost services on a stray port collision); coerce `PORT` to number.

## Verify
- `frontend` `npm run build` — pass
- `backend` `npm run build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)