### PR TITLE
docs: home-lab deploy target + [Feedback] triage in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,47 @@ After a PR merges and the GitHub Actions container publish completes, update the
 npm run deploy:pin-image -- -Commit -Push
 ```
 
-This runs `scripts/update-deploy-image.ps1`, resolves the current GHCR digest, rewrites `k8s/base/deployment.yaml`, commits the digest pin, and pushes it. Flux reconciles `k8s/base` from Git on its normal interval.
+This runs `scripts/update-deploy-image.ps1`, resolves the current GHCR digest, rewrites `k8s/base/deployment.yaml`, and commits the digest pin. Flux reconciles `k8s/base` from Git on its normal interval.
+
+**`main` is branch-protected (PR-only).** Direct `git push` to `main` is rejected (`GH013: Changes must be made through a pull request`). The `-Push` flag on the pin script will therefore fail — instead move the pin commit onto a branch and merge it via PR, same as any change:
+
+```bash
+git branch mzakhar/deploy-pin <pin-commit>   # after running the script without -Push, or salvage the local commit
+git reset --hard origin/main
+git push -u origin mzakhar/deploy-pin
+gh pr create --base main --fill && gh pr merge --squash --delete-branch
+```
+
+### Deployment target — `themachine` (home lab)
+
+- **Host**: `themachine`, Ubuntu, LAN IP `192.168.1.3` (static). SSH: `ssh mzakhar@192.168.1.3`.
+- **Orchestration**: k3s (v1.35.x) + Flux CD (GitOps). Flux runs on `themachine`, watches the separate `mzakhar/homelab-fleet` repo (`clusters/themachine/`) for the `GitRepository` + `Kustomization` that point back at this repo's `k8s/base`. So a merged digest pin in `main` is what actually triggers a rollout — a fresh `:main` image alone does not.
+- **Routing**: Traefik serves the app on the `/books/` subpath (StripPrefix middleware). Single replica; SQLite is node-local (local-path), so the workload is effectively node-pinned and cannot scale past one writer.
+- **URLs**: LAN `http://192.168.1.3/books/`; external `https://books.zakharhome.org/books/` (Cloudflare Tunnel). Backend health: `/api/health`.
+- **Verify a rollout** (from `themachine` over SSH):
+
+  ```bash
+  kubectl rollout status deploy/vs-book-app        # rollout progress
+  kubectl get pods -l app=vs-book-app -o wide       # running pod + node
+  kubectl get deploy vs-book-app -o jsonpath='{.spec.template.spec.containers[0].image}'  # live pinned digest
+  flux get kustomizations -A                         # Flux reconcile state
+  curl -s localhost/api/health                       # app health through Traefik
+  ```
+
+  Compare the live digest against `k8s/base/deployment.yaml` on `main` to confirm Flux has caught up.
+
+## Handling `[Feedback]` issues
+
+The in-app feedback widget files GitHub issues in `mzakhar/vs-book-app` via `backend/src/github.ts` — titled `[Feedback] <first 80 chars of what the user typed>`, labeled `feedback`, body being the user's raw words plus `_Reported by <name> via in-app feedback_`. **These are raw user reports, not actionable specs.**
+
+When asked to work on any issue whose title starts with `[Feedback]` (or carries the `feedback` label), the **first step is always to turn it into a well-formed issue before touching code** — do not implement straight from the raw report. That means:
+
+1. Read the raw report and infer intent; if it's ambiguous, note the assumptions rather than guessing silently.
+2. Rewrite into a clear issue: a precise title (drop the `[Feedback]` prefix), a problem statement, reproduction steps or the concrete user goal, expected vs. actual behavior, and acceptance criteria.
+3. Classify it — bug vs. feature vs. question — and relabel accordingly (keep a trace back to the original, e.g. via a comment or `triaged-from` note).
+4. Only then plan and implement against the well-formed version.
+
+One raw `[Feedback]` item may split into several concrete issues, or may be a duplicate of an existing one — say so instead of forcing a 1:1 mapping.
 
 ## Architecture
 


### PR DESCRIPTION
Adds to `CLAUDE.md`:
- **Deployment target** — `themachine` (`192.168.1.3`), k3s + Flux CD, Traefik `/books/`, single-replica node-pinned SQLite, rollout-verification commands, and the fact that `main` is PR-only (deploy pin must land via PR, not a raw push).
- **`[Feedback]` triage rule** — issues from the in-app feedback widget (`[Feedback] …`, label `feedback`) are raw user reports; first step is to rewrite them into well-formed issues before implementing.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)