### PR TITLE
feat(books): add books by scanning barcodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ React Router v6 nested layout — `Layout` wraps all routes via `<Outlet />`:
 |---|---|
 | `/` | Dashboard |
 | `/library` | BookList |
+| `/scan` | ScanPage (barcode add; HTTPS only) |
 | `/books/:id` | BookDetail |
 | `/series` | SeriesPage |
 
@@ -118,10 +119,31 @@ Three CSS themes (`dark`, `light`, `purple`) defined as CSS custom properties in
 ### Database schema
 
 - `series(id, name, total_books, created_at)`
-- `books(id, title, author, genre, status, rating, cover_url, created_at, series_id, series_position, page_count, description)` — `status` is constrained to `'unread' | 'reading' | 'read'`
+- `books(id, title, author, genre, status, rating, cover_url, created_at, series_id, series_position, page_count, description, isbn)` — `status` is constrained to `'unread' | 'reading' | 'read'`; `isbn` is a normalized 13-digit string set by barcode scanning
 - `notes(id, book_id, content, created_at, updated_at)` — cascades delete from books
 
 WAL mode and foreign keys are enabled on every connection.
+
+## Barcode scanning
+
+`/scan` (`pages/ScanPage.tsx`) adds books by camera. Bulk flow: the scanner stays open,
+each accepted barcode appends a queue row, you review and batch-save.
+
+- **Camera requires a secure context.** `http://192.168.1.3/books/` can never get camera
+  access — only `https://books.zakharhome.org/books/` works. The nav entry disables itself
+  when `!window.isSecureContext`.
+- iOS Safari has no `BarcodeDetector`, so decoding uses `zxing-wasm` (reader-only build,
+  dynamically imported). The `.wasm` is self-hosted, not CDN-loaded: `?url` import plus a
+  `locateFile` override resolves it to `/books/assets/zxing_reader-*.wasm` under the
+  `base: '/books/'` config. Changing `base` or the import style breaks it in production
+  while leaving dev working.
+- `lib/isbn.ts` is the pure core (EAN-13 checksum, 978/979 gate, ISBN-10→13). The prefix
+  gate is what rejects the UPC-5 price barcode printed beside the ISBN on most books —
+  without it, scans resolve to garbage. Self-check: `npx tsx frontend/src/lib/isbn.check.ts`.
+- Lookup is Open Library first (`lookupByIsbn` reuses the existing work-based pipeline),
+  Google Books on a miss (`api/googleBooks.ts`, no series data).
+- Duplicate detection matches in memory against `getBooks()`. Books added before this
+  feature have no ISBN, so they won't be caught until rescanned.
 
 ## OpenTelemetry
 

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -141,6 +141,7 @@ export async function getDb(): Promise<Database> {
     `ALTER TABLE users ADD COLUMN favorite_genres TEXT`,
     `ALTER TABLE users ADD COLUMN favorite_book_id INTEGER REFERENCES books(id) ON DELETE SET NULL`,
     `ALTER TABLE books ADD COLUMN is_favorite INTEGER DEFAULT 0`,
+    `ALTER TABLE books ADD COLUMN isbn TEXT`,
   ];
   for (const sql of migrations) {
     try { await _db.run(sql); } catch { /* column already exists */ }

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -6,7 +6,7 @@ import { deleteSeriesIfEmpty, findOrCreateSeries } from './series';
 const router = Router();
 
 const SELECT_BOOK = `
-  SELECT b.*, s.name as series_name, GROUP_CONCAT(DISTINCT bg.genre) as genres
+  SELECT b.*, b.isbn, s.name as series_name, GROUP_CONCAT(DISTINCT bg.genre) as genres
   FROM books b
   LEFT JOIN series s ON s.id = b.series_id
   LEFT JOIN book_genres bg ON bg.book_id = b.id
@@ -46,7 +46,7 @@ router.get('/', asyncHandler(async (req: Request, res: Response) => {
 
 router.post('/', asyncHandler(async (req: Request, res: Response) => {
   const { title, author, genre, genres, status, rating, cover_url,
-          series_name, series_position, page_count, description } = req.body;
+          series_name, series_position, page_count, description, isbn } = req.body;
   if (!title || !title.trim()) return res.status(400).json({ error: 'Title is required' });
 
   const db = await getDb();
@@ -57,8 +57,8 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
   }
 
   const result = await db.run(
-    `INSERT INTO books (title, author, status, rating, cover_url, series_id, series_position, page_count, description, user_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO books (title, author, status, rating, cover_url, series_id, series_position, page_count, description, isbn, user_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     title.trim(),
     author?.trim() || null,
     status || 'unread',
@@ -68,6 +68,7 @@ router.post('/', asyncHandler(async (req: Request, res: Response) => {
     series_position != null ? Number(series_position) : null,
     page_count ? Number(page_count) : null,
     description?.trim() || null,
+    isbn?.trim() || null,
     req.user!.id
   );
 
@@ -141,7 +142,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   if (!existing) return res.status(404).json({ error: 'Book not found' });
 
   const { title, author, genre, genres, status, rating, cover_url,
-          series_name, series_position, page_count, description } = req.body;
+          series_name, series_position, page_count, description, isbn } = req.body;
 
   let series_id: number | null = existing.series_id;
   if (series_name !== undefined) {
@@ -156,7 +157,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
   try {
     await db.run(
       `UPDATE books SET title=?, author=?, status=?, rating=?, cover_url=?,
-       series_id=?, series_position=?, page_count=?, description=? WHERE id=? AND user_id=?`,
+       series_id=?, series_position=?, page_count=?, description=?, isbn=? WHERE id=? AND user_id=?`,
       title !== undefined ? title.trim() || existing.title : existing.title,
       author !== undefined ? author?.trim() || null : existing.author,
       status !== undefined ? status : existing.status,
@@ -166,6 +167,7 @@ router.put('/:id', asyncHandler(async (req: Request, res: Response) => {
       series_position !== undefined ? (series_position != null ? Number(series_position) : null) : existing.series_position,
       page_count !== undefined ? (page_count ? Number(page_count) : null) : existing.page_count,
       description !== undefined ? description?.trim() || null : existing.description,
+      isbn !== undefined ? isbn?.trim() || null : existing.isbn,
       req.params.id, req.user!.id
     );
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.312.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.3"
+        "react-router-dom": "^6.21.3",
+        "zxing-wasm": "^3.1.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.48",
@@ -1467,6 +1468,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2372,6 +2379,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2483,6 +2517,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.2.tgz",
+      "integrity": "sha512-yHloUw+h43r9QhFwVEbdkfmsl9h3rHRpgvvVd9WdhipM3TCYYzGVACmnT+i/YPrNK/eZRgs1ZMISsyJtAoimzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "lucide-react": "^0.312.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.3"
+    "react-router-dom": "^6.21.3",
+    "zxing-wasm": "^3.1.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.48",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
 import Dashboard from './pages/Dashboard';
 import BookList from './pages/BookList';
+import ScanPage from './pages/ScanPage';
 import BookDetail from './pages/BookDetail';
 import SeriesPage from './pages/SeriesPage';
 import Wishlist from './pages/Wishlist';
@@ -40,6 +41,7 @@ export default function App() {
             >
               <Route index element={<Dashboard />} />
               <Route path="library" element={<BookList />} />
+              <Route path="scan" element={<ScanPage />} />
               <Route path="wishlist" element={<Wishlist />} />
               <Route path="books/:id" element={<BookDetail />} />
               <Route path="series" element={<SeriesPage />} />

--- a/frontend/src/api/googleBooks.ts
+++ b/frontend/src/api/googleBooks.ts
@@ -1,0 +1,28 @@
+import type { OLAutoFill } from './openLibrary';
+
+// Fallback for the Open Library miss. Google Books has no series data, so those two fields
+// are always left empty — the user fills them in during review, not a guessed heuristic.
+export async function lookupIsbnGoogleBooks(isbn: string): Promise<OLAutoFill | null> {
+  try {
+    const res = await fetch(`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data.totalItems || !data.items?.length) return null;
+
+    const info = data.items[0].volumeInfo ?? {};
+    const thumbnail: string = info.imageLinks?.thumbnail ?? '';
+
+    return {
+      title: info.title ?? '',
+      author: info.authors?.[0] ?? '',
+      cover_url: thumbnail.replace(/^http:\/\//, 'https://'),
+      page_count: info.pageCount ? String(info.pageCount) : '',
+      description: info.description ?? '',
+      series_name: '',
+      series_position: '',
+      genre: info.categories?.join(', ') ?? ''
+    };
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/api/openLibrary.ts
+++ b/frontend/src/api/openLibrary.ts
@@ -181,3 +181,55 @@ export function normalizeAutoFill(result: OLSearchResult, workDetails?: any, edi
 
   return { title, author, cover_url, page_count, description, series_name, series_position, genre };
 }
+
+// Edition-based lookup: /isbn/{isbn}.json returns an edition (not a work), so this is a thin
+// adapter into the existing work-based pipeline. Edition-specific fields (pages, cover, title)
+// override the work-level medians afterward — the scanned copy is the physical book in hand.
+export async function lookupByIsbn(isbn: string): Promise<OLAutoFill | null> {
+  try {
+    const res = await fetch(`https://openlibrary.org/isbn/${isbn}.json`);
+    if (!res.ok) return null;
+    const edition = await res.json();
+
+    const workKey: string | undefined = edition.works?.[0]?.key;
+
+    const result: OLSearchResult = {
+      key: workKey ?? '',
+      title: edition.title ?? '',
+    };
+
+    let workDetails: any = null;
+    let editions: any[] = [];
+    if (workKey) {
+      [workDetails, editions] = await Promise.all([
+        fetchWorkDetails(workKey),
+        fetchEditions(workKey)
+      ]);
+    }
+
+    const filled = normalizeAutoFill(result, workDetails, editions);
+
+    if (edition.number_of_pages) filled.page_count = String(edition.number_of_pages);
+    const editionCover = edition.covers?.find((c: number) => c > 0);
+    if (editionCover) filled.cover_url = getCoverUrl(editionCover);
+    if (edition.title) filled.title = edition.title;
+
+    // Editions rarely carry `authors` directly (see handoff) — fall back to the work's author.
+    const authorKey = edition.authors?.[0]?.key ?? workDetails?.authors?.[0]?.author?.key;
+    if (!filled.author && authorKey) {
+      try {
+        const authorRes = await fetch(`https://openlibrary.org${authorKey}.json`);
+        if (authorRes.ok) {
+          const authorData = await authorRes.json();
+          if (authorData.name) filled.author = authorData.name;
+        }
+      } catch {
+        // best effort
+      }
+    }
+
+    return filled;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Camera, Keyboard, X } from 'lucide-react';
+import { isBookEan } from '../lib/isbn';
+import wasmUrl from 'zxing-wasm/reader/zxing_reader.wasm?url';
+
+interface Props {
+  onScan: (ean: string) => void;
+  onClose?: () => void;
+}
+
+// Suppress repeat emits of the same barcode while it's still in frame.
+const DEDUPE_WINDOW_MS = 3000;
+// ~5 decodes/sec — every frame pegs the CPU for no accuracy gain.
+const DECODE_INTERVAL_MS = 200;
+
+type ScanError = 'insecure' | 'denied' | 'no-camera' | 'other' | null;
+
+let zxingReady: Promise<typeof import('zxing-wasm/reader')> | null = null;
+function loadZxing() {
+  if (!zxingReady) {
+    zxingReady = import('zxing-wasm/reader').then(mod => {
+      mod.prepareZXingModule({
+        overrides: { locateFile: (path: string) => (path.endsWith('.wasm') ? wasmUrl : path) },
+      });
+      return mod;
+    });
+  }
+  return zxingReady;
+}
+
+export default function BarcodeScanner({ onScan, onClose }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const lastDecodeAtRef = useRef(0);
+  const seenRef = useRef<Map<string, number>>(new Map());
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  // Set synchronously before the first await in start(), so a double-tap cannot open a
+  // second getUserMedia and orphan the first stream (leaves the iPad camera light on).
+  // `active` is state and would still read false on both taps in the same tick.
+  const startingRef = useRef(false);
+
+  const [active, setActive] = useState(false);
+  const [flash, setFlash] = useState(false);
+  const [error, setError] = useState<ScanError>(null);
+  const [manualIsbn, setManualIsbn] = useState('');
+
+  const stop = () => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+    setActive(false);
+  };
+
+  useEffect(() => stop, []);
+
+  const beep = () => {
+    const ctx = audioCtxRef.current ?? new AudioContext();
+    audioCtxRef.current = ctx;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = 880;
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.12);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.12);
+  };
+
+  const accept = (ean: string) => {
+    const now = Date.now();
+    const lastSeen = seenRef.current.get(ean);
+    if (lastSeen && now - lastSeen < DEDUPE_WINDOW_MS) return;
+    seenRef.current.set(ean, now);
+    setFlash(true);
+    setTimeout(() => setFlash(false), 200);
+    beep();
+    onScan(ean);
+  };
+
+  const decodeLoop = async (readBarcodes: typeof import('zxing-wasm/reader').readBarcodes) => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas || video.readyState < 2) {
+      rafRef.current = requestAnimationFrame(() => decodeLoop(readBarcodes));
+      return;
+    }
+    const now = performance.now();
+    if (now - lastDecodeAtRef.current >= DECODE_INTERVAL_MS) {
+      lastDecodeAtRef.current = now;
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        try {
+          const results = await readBarcodes(imageData, { formats: ['EAN-13', 'UPC-A'] });
+          for (const r of results) {
+            if (isBookEan(r.text)) {
+              accept(r.text);
+              break;
+            }
+          }
+        } catch {
+          // decode failure on a single frame — try again next tick
+        }
+      }
+    }
+    rafRef.current = requestAnimationFrame(() => decodeLoop(readBarcodes));
+  };
+
+  const start = async () => {
+    if (startingRef.current || streamRef.current) return;
+    startingRef.current = true;
+    setError(null);
+    if (!window.isSecureContext) {
+      setError('insecure');
+      startingRef.current = false;
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+      setActive(true);
+      const { readBarcodes } = await loadZxing();
+      rafRef.current = requestAnimationFrame(() => decodeLoop(readBarcodes));
+    } catch (err: any) {
+      stop();
+      if (err?.name === 'NotAllowedError') setError('denied');
+      else if (err?.name === 'NotFoundError') setError('no-camera');
+      else setError('other');
+    } finally {
+      startingRef.current = false;
+    }
+  };
+
+  const handleManualSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const isbn = manualIsbn.trim();
+    if (!isbn) return;
+    onScan(isbn);
+    setManualIsbn('');
+  };
+
+  const handleClose = () => {
+    stop();
+    onClose?.();
+  };
+
+  return (
+    <div className="barcode-scanner">
+      <div className="barcode-scanner__viewfinder">
+        {active ? (
+          <>
+            <video ref={videoRef} playsInline muted className="barcode-scanner__video" />
+            <div className={`barcode-scanner__flash${flash ? ' barcode-scanner__flash--active' : ''}`} />
+            <div className="barcode-scanner__frame" />
+          </>
+        ) : (
+          <div className="barcode-scanner__placeholder">
+            <Camera size={32} />
+            <button type="button" className="btn btn--primary" onClick={start}>
+              Start camera
+            </button>
+          </div>
+        )}
+        <canvas ref={canvasRef} style={{ display: 'none' }} />
+        {onClose && (
+          <button type="button" className="barcode-scanner__close" onClick={handleClose} title="Close scanner">
+            <X size={16} />
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="barcode-scanner__error">
+          <AlertTriangle size={16} />
+          {error === 'insecure' && (
+            <span>
+              Camera scanning needs HTTPS. The LAN address won't work — use{' '}
+              <strong>https://books.zakharhome.org/books/</strong> instead.
+            </span>
+          )}
+          {error === 'denied' && (
+            <span>
+              Camera permission was denied. Re-enable it in Settings → Safari → Camera on iPad.
+            </span>
+          )}
+          {error === 'no-camera' && <span>No camera was found on this device.</span>}
+          {error === 'other' && <span>Could not start the camera. Try again or enter the ISBN below.</span>}
+        </div>
+      )}
+
+      <form className="barcode-scanner__manual" onSubmit={handleManualSubmit}>
+        <label className="form-label">
+          <Keyboard size={14} /> Enter ISBN manually
+        </label>
+        <div className="barcode-scanner__manual-row">
+          <input
+            className="form-input"
+            value={manualIsbn}
+            onChange={e => setManualIsbn(e.target.value)}
+            placeholder="978…"
+            inputMode="numeric"
+          />
+          <button type="submit" className="btn btn--secondary" disabled={!manualIsbn.trim()}>
+            Add
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/BookForm.tsx
+++ b/frontend/src/components/BookForm.tsx
@@ -33,11 +33,13 @@ function compressImage(file: File): Promise<string> {
 
 interface Props {
   existing?: Book;
+  /** Seeds the isbn field when a scan resolved no metadata and the user fills the book in by hand. */
+  initialIsbn?: string;
   onSave: (book: Book) => void;
   onCancel: () => void;
 }
 
-export default function BookForm({ existing, onSave, onCancel }: Props) {
+export default function BookForm({ existing, initialIsbn, onSave, onCancel }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [form, setForm] = useState({
@@ -51,6 +53,7 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
     series_position: existing?.series_position != null ? String(existing.series_position) : '',
     page_count:      existing?.page_count      != null ? String(existing.page_count) : '',
     description:     existing?.description     ?? '',
+    isbn:            existing?.isbn            ?? initialIsbn ?? '',
   });
 
   // OL search state
@@ -150,6 +153,7 @@ export default function BookForm({ existing, onSave, onCancel }: Props) {
         series_position: form.series_position !== '' ? Number(form.series_position) : undefined,
         page_count:      form.page_count !== '' ? Number(form.page_count) : undefined,
         description:     form.description.trim() || undefined,
+        isbn:            form.isbn.trim() || undefined,
       };
       const book = existing?.id != null
         ? await updateBook(existing.id, payload)

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut, UserCircle2, ChevronDown, ChevronUp, Pencil, MessageSquare, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { BookOpen, LayoutDashboard, BookMarked, Star, Palette, Users, LogOut, UserCircle2, ChevronDown, ChevronUp, Pencil, MessageSquare, PanelLeftClose, PanelLeftOpen, ScanLine } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { getMyProfile } from '../api';
 import type { UserProfile } from '../types';
@@ -222,6 +222,23 @@ export default function Layout() {
             <BookOpen />
             <span className="nav-item__label">My Library</span>
           </NavLink>
+          {window.isSecureContext ? (
+            <NavLink
+              to="/scan"
+              className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}
+            >
+              <ScanLine />
+              <span className="nav-item__label">Scan</span>
+            </NavLink>
+          ) : (
+            <span
+              className="nav-item nav-item--disabled"
+              title="Camera scanning needs HTTPS — use https://books.zakharhome.org/books/ instead of the LAN address."
+            >
+              <ScanLine />
+              <span className="nav-item__label">Scan</span>
+            </span>
+          )}
           <NavLink
             to="/wishlist"
             className={({ isActive }) => `nav-item${isActive ? ' nav-item--active' : ''}`}

--- a/frontend/src/lib/isbn.check.ts
+++ b/frontend/src/lib/isbn.check.ts
@@ -1,0 +1,44 @@
+import { ean13Checksum, isBookEan, normalizeIsbn } from './isbn';
+
+// Frontend tsconfig has no @types/node (no other agent's file to add it to),
+// so this stays a plain assert instead of `node:assert` to keep `tsc` clean.
+function assertEqual(actual: unknown, expected: unknown, message?: string) {
+  if (actual !== expected) {
+    throw new Error(message ?? `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+const assert = { strictEqual: assertEqual };
+
+// Valid ISBN-13 (checksum verified by hand: sum=90, check=0)
+assert.strictEqual(isBookEan('9780553103540'), true, 'valid 978 EAN should be accepted');
+assert.strictEqual(normalizeIsbn('9780553103540'), '9780553103540');
+
+// Same digits, last digit corrupted -> bad checksum
+assert.strictEqual(isBookEan('9780553103541'), false, 'corrupted checksum should be rejected');
+assert.strictEqual(normalizeIsbn('9780553103541'), null);
+
+// 12-digit UPC-A and 5-digit price add-on -> rejected
+assert.strictEqual(isBookEan('036000291452'), false, '12-digit UPC-A should be rejected');
+assert.strictEqual(normalizeIsbn('036000291452'), null);
+assert.strictEqual(isBookEan('90000'), false, '5-digit price add-on should be rejected');
+assert.strictEqual(normalizeIsbn('90000'), null);
+
+// Valid 979-prefixed EAN (checksum computed: 9791234567896)
+assert.strictEqual(isBookEan('9791234567896'), true, 'valid 979 EAN should be accepted');
+assert.strictEqual(ean13Checksum('9791234567896'), true);
+
+// ISBN-10 with 'X' check digit converts to the correct ISBN-13
+// 080442957X (valid ISBN-10) -> 9780804429573
+assert.strictEqual(normalizeIsbn('080442957X'), '9780804429573');
+assert.strictEqual(normalizeIsbn('080442957x'), '9780804429573', 'lowercase x should also work');
+
+// Hyphenated input normalizes
+assert.strictEqual(normalizeIsbn('978-0-553-10354-0'), '9780553103540');
+assert.strictEqual(normalizeIsbn('0-8044-2957-X'), '9780804429573');
+
+// Garbage / empty string -> null
+assert.strictEqual(normalizeIsbn(''), null);
+assert.strictEqual(normalizeIsbn('not an isbn'), null);
+assert.strictEqual(isBookEan(''), false);
+
+console.log('isbn.check.ts OK');

--- a/frontend/src/lib/isbn.ts
+++ b/frontend/src/lib/isbn.ts
@@ -1,0 +1,53 @@
+// Pure ISBN/EAN-13 core. No IO, no deps.
+
+export function ean13Checksum(digits: string): boolean {
+  if (!/^\d{13}$/.test(digits)) return false;
+  let sum = 0;
+  for (let i = 0; i < 12; i++) {
+    sum += Number(digits[i]) * (i % 2 === 0 ? 1 : 3);
+  }
+  const check = (10 - (sum % 10)) % 10;
+  return check === Number(digits[12]);
+}
+
+export function isBookEan(raw: string): boolean {
+  const digits = raw.replace(/[-\s]/g, '');
+  if (!/^\d{13}$/.test(digits)) return false;
+  if (!digits.startsWith('978') && !digits.startsWith('979')) return false;
+  return ean13Checksum(digits);
+}
+
+function isbn10Checksum(digits: string): boolean {
+  if (!/^\d{9}[\dXx]$/.test(digits)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += Number(digits[i]) * (10 - i);
+  }
+  const last = digits[9].toUpperCase();
+  sum += (last === 'X' ? 10 : Number(last)) * 1;
+  return sum % 11 === 0;
+}
+
+function isbn10to13(isbn10: string): string {
+  const core = '978' + isbn10.slice(0, 9);
+  let sum = 0;
+  for (let i = 0; i < 12; i++) {
+    sum += Number(core[i]) * (i % 2 === 0 ? 1 : 3);
+  }
+  const check = (10 - (sum % 10)) % 10;
+  return core + check;
+}
+
+export function normalizeIsbn(raw: string): string | null {
+  const cleaned = raw.replace(/[^0-9Xx]/g, '');
+
+  if (cleaned.length === 13 && isBookEan(cleaned)) {
+    return cleaned;
+  }
+
+  if (cleaned.length === 10 && isbn10Checksum(cleaned)) {
+    return isbn10to13(cleaned);
+  }
+
+  return null;
+}

--- a/frontend/src/pages/ScanPage.tsx
+++ b/frontend/src/pages/ScanPage.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertTriangle, BookOpen, Loader, X } from 'lucide-react';
+import { getBooks, createBook } from '../api';
+import type { Book, BookStatus } from '../types';
+import { normalizeIsbn } from '../lib/isbn';
+import { lookupByIsbn } from '../api/openLibrary';
+import type { OLAutoFill } from '../api/openLibrary';
+import { lookupIsbnGoogleBooks } from '../api/googleBooks';
+import BarcodeScanner from '../components/BarcodeScanner';
+import Modal from '../components/Modal';
+import BookForm from '../components/BookForm';
+import { useToast } from '../components/Toast';
+
+// Mirrors BookForm.tsx:9-14 — not exported from there, so kept in sync by hand.
+const STATUSES: { value: BookStatus; label: string }[] = [
+  { value: 'unread', label: 'Unread' },
+  { value: 'reading', label: 'Reading' },
+  { value: 'read', label: 'Read' },
+  { value: 'wishlist', label: 'Wishlist' },
+];
+
+type LookupState = 'looking-up' | 'resolved' | 'unresolved';
+type SaveState = 'idle' | 'saving' | 'failed';
+
+interface Row {
+  ean: string;
+  state: LookupState;
+  data?: OLAutoFill;
+  status: BookStatus;
+  duplicateOf?: Book;
+  include: boolean;
+  saveState: SaveState;
+  saveError?: string;
+}
+
+function toPayload(row: Row) {
+  const d = row.data!;
+  return {
+    title: d.title.trim() || row.ean,
+    author: d.author.trim() || undefined,
+    genres: d.genre.split(',').map(g => g.trim()).filter(g => g !== ''),
+    status: row.status,
+    cover_url: d.cover_url.trim() || undefined,
+    series_name: d.series_name.trim() || '',
+    series_position: d.series_position !== '' ? Number(d.series_position) : undefined,
+    page_count: d.page_count !== '' ? Number(d.page_count) : undefined,
+    description: d.description.trim() || undefined,
+    isbn: row.ean,
+  };
+}
+
+export default function ScanPage() {
+  const { toast } = useToast();
+  const [rows, setRows] = useState<Row[]>([]);
+  const [savingAll, setSavingAll] = useState(false);
+  const [manualEan, setManualEan] = useState<string | null>(null);
+  // Books already owned, keyed by isbn — checked against on scan and updated after every save.
+  const bookByIsbnRef = useRef<Map<string, Book>>(new Map());
+
+  useEffect(() => {
+    getBooks().then(books => {
+      // ponytail: in-memory dupe check against the full book list. Fine at personal-library
+      // scale; add an idx_books_user_isbn index and a /api/books/by-isbn route if it ever gets slow.
+      const map = new Map<string, Book>();
+      for (const b of books) {
+        if (b.isbn) map.set(b.isbn, b);
+      }
+      bookByIsbnRef.current = map;
+    }).catch(() => {});
+  }, []);
+
+  const resolveRow = async (ean: string) => {
+    let data = await lookupByIsbn(ean);
+    if (!data) data = await lookupIsbnGoogleBooks(ean);
+    setRows(prev => prev.map(r => r.ean === ean ? { ...r, state: data ? 'resolved' : 'unresolved', data: data ?? undefined } : r));
+  };
+
+  const handleScan = (raw: string) => {
+    const ean = normalizeIsbn(raw);
+    if (!ean) return;
+    let added = false;
+    setRows(prev => {
+      if (prev.some(r => r.ean === ean)) return prev;
+      added = true;
+      const duplicateOf = bookByIsbnRef.current.get(ean);
+      return [...prev, {
+        ean,
+        state: 'looking-up',
+        status: 'unread',
+        include: !duplicateOf,
+        saveState: 'idle',
+        duplicateOf,
+      }];
+    });
+    if (added) resolveRow(ean);
+  };
+
+  const removeRow = (ean: string) => setRows(prev => prev.filter(r => r.ean !== ean));
+
+  const setRowStatus = (ean: string, status: BookStatus) =>
+    setRows(prev => prev.map(r => r.ean === ean ? { ...r, status } : r));
+
+  const setRowInclude = (ean: string, include: boolean) =>
+    setRows(prev => prev.map(r => r.ean === ean ? { ...r, include } : r));
+
+  const resolvedIncludedCount = rows.filter(r => r.state === 'resolved' && r.include).length;
+
+  const handleSaveAll = async () => {
+    const toSave = rows.filter(r => r.state === 'resolved' && r.include);
+    if (toSave.length === 0) return;
+    setSavingAll(true);
+    let savedCount = 0;
+    // Sequential, not Promise.all — SQLite single writer, and findOrCreateSeries races on
+    // concurrent inserts for the same series name.
+    for (const row of toSave) {
+      setRows(prev => prev.map(r => r.ean === row.ean ? { ...r, saveState: 'saving' } : r));
+      try {
+        const book = await createBook(toPayload(row));
+        bookByIsbnRef.current.set(row.ean, book);
+        savedCount++;
+        setRows(prev => prev.filter(r => r.ean !== row.ean));
+      } catch (err: any) {
+        setRows(prev => prev.map(r => r.ean === row.ean
+          ? { ...r, saveState: 'failed', saveError: err?.response?.data?.error || 'Save failed.' }
+          : r));
+      }
+    }
+    setSavingAll(false);
+    if (savedCount > 0) toast('success', `Saved ${savedCount} book${savedCount !== 1 ? 's' : ''}.`);
+  };
+
+  const handleManualSave = (book: Book) => {
+    if (book.isbn) bookByIsbnRef.current.set(book.isbn, book);
+    if (manualEan) removeRow(manualEan);
+    setManualEan(null);
+    toast('success', 'Book added.');
+  };
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h1>Scan Books</h1>
+          <p className="page-subtitle">{rows.length} in queue</p>
+        </div>
+        <div className="page-header__actions">
+          <button
+            type="button"
+            className="btn btn--primary"
+            onClick={handleSaveAll}
+            disabled={savingAll || resolvedIncludedCount === 0}
+          >
+            {savingAll ? 'Saving…' : `Save all (${resolvedIncludedCount})`}
+          </button>
+        </div>
+      </div>
+
+      <BarcodeScanner onScan={handleScan} />
+
+      <div className="scan-queue">
+        {rows.length === 0 && (
+          <p className="scan-queue__empty">Scan a barcode, or enter an ISBN above, to add it to the queue.</p>
+        )}
+        {rows.map(row => (
+          <div key={row.ean} className={`scan-row${row.duplicateOf ? ' scan-row--duplicate' : ''}`}>
+            <div className="scan-row__cover">
+              {row.data?.cover_url ? <img src={row.data.cover_url} alt="" /> : <BookOpen size={22} />}
+            </div>
+            <div className="scan-row__info">
+              <div className="scan-row__title">{row.data?.title || row.ean}</div>
+              {row.data?.author && <div className="scan-row__author">{row.data.author}</div>}
+              <div className="scan-row__ean">{row.ean}</div>
+              {row.state === 'looking-up' && (
+                <span className="scan-row__note">
+                  <Loader size={13} className="scan-row__spinner" /> Looking up…
+                </span>
+              )}
+              {row.state === 'unresolved' && (
+                <span className="scan-row__note scan-row__note--warn">No match found — fill in manually.</span>
+              )}
+              {row.duplicateOf && (
+                <span className="scan-row__note scan-row__note--warn">
+                  <AlertTriangle size={13} /> Already in your library —{' '}
+                  <Link to={`/books/${row.duplicateOf.id}`}>view existing</Link>
+                </span>
+              )}
+              {row.saveState === 'failed' && (
+                <span className="scan-row__note scan-row__note--warn">{row.saveError}</span>
+              )}
+            </div>
+            <div className="scan-row__actions">
+              {row.state === 'resolved' && (
+                <>
+                  <label className="scan-row__include">
+                    <input
+                      type="checkbox"
+                      checked={row.include}
+                      onChange={e => setRowInclude(row.ean, e.target.checked)}
+                    />
+                    Save
+                  </label>
+                  <select
+                    className="form-select"
+                    value={row.status}
+                    onChange={e => setRowStatus(row.ean, e.target.value as BookStatus)}
+                  >
+                    {STATUSES.map(s => (
+                      <option key={s.value} value={s.value}>{s.label}</option>
+                    ))}
+                  </select>
+                </>
+              )}
+              {row.state === 'unresolved' && (
+                <button type="button" className="btn btn--secondary" onClick={() => setManualEan(row.ean)}>
+                  Fill manually
+                </button>
+              )}
+              {row.saveState === 'saving' ? (
+                <Loader size={16} className="scan-row__spinner" />
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn--icon btn--ghost"
+                  onClick={() => removeRow(row.ean)}
+                  title="Remove from queue"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {manualEan && (
+        <Modal title="Add Book" onClose={() => setManualEan(null)} size="md">
+          <BookForm
+            initialIsbn={manualEan}
+            onSave={handleManualSave}
+            onCancel={() => setManualEan(null)}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -1552,3 +1552,218 @@
 .message-compose__count {
   align-self: flex-end;
 }
+
+// ── Barcode Scanner ────────────────────────────────────────────────────────
+.barcode-scanner {
+  display: flex;
+  flex-direction: column;
+  gap: $space-4;
+
+  &__viewfinder {
+    position: relative;
+    aspect-ratio: 4 / 3;
+    border-radius: $radius-lg;
+    border: 1px solid $border-light;
+    background: $bg-elevated;
+    overflow: hidden;
+    backdrop-filter: var(--glass-blur);
+  }
+
+  &__video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__placeholder {
+    @include flex-center;
+    flex-direction: column;
+    gap: $space-3;
+    width: 100%;
+    height: 100%;
+    color: $text-3;
+
+    svg { opacity: 0.5; }
+  }
+
+  &__frame {
+    position: absolute;
+    inset: 20% 8%;
+    border: 2px solid $accent-muted;
+    border-radius: $radius;
+    pointer-events: none;
+  }
+
+  &__flash {
+    position: absolute;
+    inset: 0;
+    background: #fff;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 100ms ease;
+
+    &--active { opacity: 0.6; }
+  }
+
+  &__close {
+    position: absolute;
+    top: $space-2;
+    right: $space-2;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    @include flex-center;
+    transition: background $transition;
+
+    &:hover, &:focus-visible { background: var(--danger); }
+  }
+
+  &__error {
+    display: flex;
+    align-items: flex-start;
+    gap: $space-2;
+    padding: $space-3;
+    background: $danger-bg;
+    border: 1px solid var(--danger-border);
+    border-radius: $radius;
+    color: $danger;
+    font-size: 0.8125rem;
+
+    svg { flex-shrink: 0; margin-top: 2px; }
+  }
+
+  &__manual {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+
+    .form-label {
+      display: inline-flex;
+      align-items: center;
+      gap: $space-1;
+    }
+  }
+
+  &__manual-row {
+    display: flex;
+    gap: $space-2;
+  }
+}
+
+// ── Scan Page ─────────────────────────────────────────────────────────────
+.nav-item--disabled {
+  cursor: not-allowed;
+  color: $text-4;
+  opacity: 0.5;
+
+  &:hover { background: none; color: $text-4; }
+}
+
+.scan-queue {
+  display: flex;
+  flex-direction: column;
+  gap: $space-3;
+  margin-top: $space-4;
+}
+
+.scan-queue__empty {
+  color: $text-3;
+  font-size: 0.875rem;
+  padding: $space-4;
+  text-align: center;
+}
+
+.scan-row {
+  display: flex;
+  align-items: center;
+  gap: $space-4;
+  padding: $space-3;
+  border-radius: $radius-lg;
+  border: 1px solid $border-light;
+  background: $bg-card;
+  backdrop-filter: var(--glass-blur);
+  flex-wrap: wrap;
+
+  &--duplicate {
+    border-color: var(--danger-border);
+  }
+
+  &__cover {
+    @include flex-center;
+    flex-shrink: 0;
+    width: 44px;
+    height: 64px;
+    border-radius: $radius-sm;
+    background: $bg-elevated;
+    color: $text-3;
+    overflow: hidden;
+
+    img { width: 100%; height: 100%; object-fit: cover; }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1 1 200px;
+    min-width: 0;
+  }
+
+  &__title {
+    font-weight: 600;
+    color: $text-1;
+    @include truncate;
+  }
+
+  &__author {
+    font-size: 0.8125rem;
+    color: $text-2;
+    @include truncate;
+  }
+
+  &__ean {
+    font-size: 0.75rem;
+    color: $text-4;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__note {
+    display: inline-flex;
+    align-items: center;
+    gap: $space-1;
+    font-size: 0.8125rem;
+    color: $text-3;
+
+    &--warn { color: $danger; }
+  }
+
+  &__spinner {
+    animation: spin 0.8s linear infinite;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: $space-3;
+    flex-shrink: 0;
+
+    .form-select { width: auto; min-width: 110px; }
+  }
+
+  &__include {
+    display: inline-flex;
+    align-items: center;
+    gap: $space-1;
+    font-size: 0.8125rem;
+    color: $text-2;
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .scan-row {
+    &__actions { width: 100%; justify-content: space-between; }
+  }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,6 +60,7 @@ export interface Book {
   page_count?: number | null;
   description?: string | null;
   is_favorite?: number;
+  isbn?: string | null;
 }
 
 export interface BookStats {

--- a/plans/barcode-scanning.md
+++ b/plans/barcode-scanning.md
@@ -1,0 +1,144 @@
+# Barcode scanning — add books by camera
+
+## Decisions (locked)
+
+| Question | Answer |
+|---|---|
+| Capture | Live camera scan, continuous decode |
+| Flow | Bulk queue — scanner stays open, review + batch save at end |
+| Metadata | Open Library first, Google Books fallback on 404 |
+| Miss | Drop into `BookForm` prefilled with the ISBN |
+| Duplicate | Warn in the queue, offer to open the existing book |
+
+## Hard constraints
+
+1. **HTTPS only.** `getUserMedia` requires a secure context. `http://192.168.1.3/books/` will
+   never get camera access on iPad. The feature is usable only via
+   `https://books.zakharhome.org/books/`. Nav entry should detect
+   `!window.isSecureContext` and show why it's disabled rather than failing silently at tap.
+2. **No `BarcodeDetector` on iOS Safari.** Chromium-only API. Requires a WASM decoder —
+   `zxing-wasm`. This is the first new frontend dependency in the project. Dynamic-import it
+   so it stays out of the main bundle.
+3. **Books often carry two barcodes.** The EAN-13 (ISBN) plus a UPC-5 price add-on, and some
+   have a separate UPC-A. Decoder must accept only EAN-13 with a `978`/`979` prefix and a
+   valid checksum. Without that gate, the price barcode produces junk lookups.
+4. **iPad Safari video quirks:** `<video>` needs `playsInline` + `muted` or it forces
+   fullscreen playback. No torch/flash control available in Safari. Camera start needs a user
+   gesture.
+5. **Books are per-user** (`books.user_id`). Dedupe is per-user, never global.
+
+## What already exists and gets reused
+
+- `frontend/src/api/openLibrary.ts` — `fetchWorkDetails`, `fetchEditions`, `normalizeAutoFill`.
+  The whole series-detection heuristic stays untouched.
+- `frontend/src/components/BookForm.tsx` — the miss path opens this, unchanged except for one
+  new optional prop.
+- `POST /api/books` — batch save is just this in a loop from the client. No batch endpoint.
+- `backend/src/database.ts` migrations array (`database.ts:132`) — the established pattern for
+  adding a column.
+
+**Key integration insight:** the existing OL pipeline is *work*-based
+(`/works/OL…W` → editions → normalize). An ISBN lookup returns an *edition*. So the new lookup
+is a thin adapter: ISBN → edition JSON → `works[0].key` → hand to the existing pipeline. No
+duplication of the series logic.
+
+## Files
+
+### Backend (3 small edits)
+
+| File | Change |
+|---|---|
+| `backend/src/database.ts:143` | Append `` `ALTER TABLE books ADD COLUMN isbn TEXT` `` to the migrations array |
+| `backend/src/routes/books.ts:48,60` | Destructure `isbn` in POST, add to the INSERT column list + values |
+| `backend/src/routes/books.ts` | Add `b.isbn` to `SELECT_BOOK`; accept `isbn` in PUT |
+
+No new route. No index yet — see the ponytail note under Dedupe.
+
+### Frontend
+
+**`frontend/src/lib/isbn.ts`** — pure, no IO. The functional core of this feature.
+
+```ts
+export function isBookEan(raw: string): boolean      // EAN-13, 978/979 prefix, checksum valid
+export function normalizeIsbn(raw: string): string | null  // ISBN-10 → 13, strip hyphens/spaces
+export function ean13Checksum(digits: string): boolean
+```
+
+**`frontend/src/lib/isbn.check.ts`** — the one runnable check. Plain `assert` calls, no
+framework. Run: `npx tsx frontend/src/lib/isbn.check.ts`. Cases: valid ISBN-13, bad checksum,
+UPC price add-on rejected, `979` accepted, ISBN-10 with `X` check digit converts correctly.
+
+**`frontend/src/api/openLibrary.ts`** — add:
+
+```ts
+export async function lookupByIsbn(isbn: string): Promise<OLAutoFill | null>
+```
+Fetches `https://openlibrary.org/isbn/{isbn}.json`, pulls `works[0].key`, then reuses
+`fetchWorkDetails` + `fetchEditions` + `normalizeAutoFill`. Prefers the *edition's* own
+`number_of_pages` and `covers[0]` over the work-level medians — the scanned edition is the one
+in hand. Returns `null` on 404.
+
+**`frontend/src/api/googleBooks.ts`** — new, ~40 lines. Hits
+`https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}` (no API key needed for this),
+maps `volumeInfo` → the same `OLAutoFill` shape. No series data — Google Books has none, so
+those two fields come back empty and the user fills them in the review step.
+
+**`frontend/src/components/BarcodeScanner.tsx`** — the imperative shell.
+- `getUserMedia({ video: { facingMode: 'environment' } })`
+- `requestAnimationFrame` loop, throttled to ~5 decodes/sec, draws to an offscreen canvas
+- `await import('zxing-wasm')` on mount
+- Filters every decode through `isBookEan`
+- Debounces repeat hits of the same ISBN for 3s (the barcode stays in frame after a hit)
+- Beep + flash on accept; `onScan(isbn)` callback
+- Cleans up the `MediaStream` on unmount — a leaked camera light on the iPad is the bug
+  everyone ships first
+
+**`frontend/src/pages/ScanPage.tsx`** — bulk queue.
+- Renders `<BarcodeScanner>` above a growing queue list
+- Each hit: `lookupByIsbn` → on `null`, Google Books → on `null`, queue as `unresolved`
+- Queue row shows cover, title, author, status dropdown, and a remove button
+- Duplicate rows render a warning badge with a link to the existing book
+- "Save all" posts each resolved row via the existing `createBook`, sequentially
+- Unresolved rows get a "Fill manually" button that opens `BookForm` with `initialIsbn` set
+
+**`frontend/src/components/BookForm.tsx`** — one new optional prop `initialIsbn?: string`,
+seeded into form state, submitted as `isbn`. Nothing else changes.
+
+**`frontend/src/App.tsx` + `Layout.tsx`** — route `/scan`, nav entry with a `ScanLine` icon
+(already in `lucide-react`, no new dep). Hide or disable the entry when
+`!window.isSecureContext`.
+
+### Dedupe
+
+`ScanPage` calls the existing `getBooks()` once on mount and matches ISBNs in memory.
+
+```ts
+// ponytail: in-memory dupe check against the full book list. Fine at personal-library
+// scale; add an idx_books_user_isbn index and a /api/books/by-isbn route if it ever gets slow.
+```
+
+Existing books have no ISBN, so early scans of already-owned books won't be caught. Acceptable
+— it backfills naturally as books are rescanned.
+
+## Phases
+
+1. **Pure core + schema** — `isbn.ts`, `isbn.check.ts`, the DB migration, backend passthrough,
+   `Book.isbn` type. Verify: check script passes, `npm run build` clean in both workspaces,
+   POST a book with an ISBN via curl and read it back.
+2. **Lookup layer** — `lookupByIsbn`, `googleBooks.ts`. Verify: a scratch script resolving five
+   real ISBNs off your shelf, including one deliberately obscure one to prove the fallback
+   fires.
+3. **Scanner component** — camera + decode, standalone, dumping results to the console.
+   Verify on the actual iPad against `https://books.zakharhome.org/books/`. **This is the phase
+   most likely to surprise us** — everything before it is testable on the desktop, this is not.
+4. **ScanPage** — queue, dedupe, review, batch save.
+5. **Wire-up** — route, nav, `BookForm` prop.
+
+## Open risks
+
+- `zxing-wasm` bundle size and whether Vite's WASM handling needs config for the k8s subpath
+  deploy (`/books/` base). Worth a 10-minute spike in phase 3 before building the queue UI.
+- Decode reliability on glossy covers under household lighting. If it's poor, the mitigation is
+  a manual "enter ISBN" field in the scanner, not a better decoder.
+- Open Library's `/isbn/` endpoint returns 302s to the edition key; `fetch` follows by default,
+  but confirm the JSON shape matches what phase 2 expects.


### PR DESCRIPTION
Adds `/scan` — add books to the library by scanning their barcode on the iPad.

Bulk flow: the camera stays open, each accepted barcode appends a queue row, metadata resolves in the background, you review and batch-save at the end.

## How it works

| Piece | File |
|---|---|
| Pure ISBN core (EAN-13 checksum, 978/979 gate, ISBN-10→13) | `lib/isbn.ts` |
| ISBN → metadata, Open Library then Google Books | `api/openLibrary.ts`, `api/googleBooks.ts` |
| Camera + zxing-wasm decode loop | `components/BarcodeScanner.tsx` |
| Bulk queue, duplicate detection, batch save | `pages/ScanPage.tsx` |
| `isbn` column, route, nav entry | `database.ts`, `books.ts`, `App.tsx`, `Layout.tsx` |

Three design notes worth knowing:

- **`lookupByIsbn` is an adapter, not a new pipeline.** The existing OL flow is *work*-based; an ISBN returns an *edition*. So it resolves edition → `works[0].key` → hands off to the existing code. The series-detection heuristic is reused untouched.
- **The 978/979 prefix gate is load-bearing.** Most books carry a second UPC-5 price barcode next to the ISBN. Without the gate, those decode fine and resolve to garbage.
- **The `.wasm` is self-hosted, not CDN-loaded.** zxing-wasm defaults to jsDelivr; a `?url` import plus a `locateFile` override resolves it to `/books/assets/` under `base: '/books/'`. Changing `base` or the import style breaks production while leaving dev working.

## Camera requires HTTPS

`getUserMedia` needs a secure context, so this works only on `https://books.zakharhome.org/books/` — the LAN `http://192.168.1.3/books/` URL can never grant camera access. The nav entry disables itself with a tooltip when `!window.isSecureContext`. A manual ISBN-entry field is built into the scanner as the fallback for poor decode conditions.

## Verified

- Both workspaces build clean; wasm asset emits and the baked URL is `/books/assets/zxing_reader-*.wasm`
- `npx tsx frontend/src/lib/isbn.check.ts` passes (valid/invalid checksums, UPC rejection, 979 prefix, ISBN-10 with `X`, hyphens, garbage)
- Real Open Library lookups against live ISBNs; `createBook` round-trips `isbn` through the real DB
- Review caught a double-tap race in `start()` that orphaned a MediaStream and left the camera light on — fixed with a ref guard set synchronously before the first `await`

## Not verified — needs hardware

- **The decoder has never decoded anything.** No camera on the dev box. Everything downstream of it is exercised; the zxing path itself is not.
- **Google Books fallback never returned a live hit** — the dev network's shared quota is 429-exhausted. Code is correct and a 429 degrades to the manual-entry path, but no real fallback was observed.
- `ScanPage` DOM rendering and click-through are code-reviewed only (port 3000 is held by Grafana locally).

First real test is on the iPad after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd