### PR TITLE
chore(deploy): pin image for barcode scanning

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:8abfd888d8e9c4cace95efaae940878c098cb43c1d9357efc716584059d1074f
+          image: ghcr.io/mzakhar/vs-book-app@sha256:5cc7562596a4c308ca0b545365473749c9696e26a9539324049124764dc03b70
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pins `k8s/base/deployment.yaml` to the GHCR digest built from 9acfc8d (barcode scanning, #47).

`sha256:8abfd888` → `sha256:5cc75625`

Flux reconciles `k8s/base` from Git, so this is what actually triggers the rollout on `themachine` — the `:main` image publish alone does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd