### PR TITLE
fix(ui): make the app usable on a phone

### DIFF
--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -152,7 +152,7 @@ export default function BookDetail() {
       </Link>
 
       {/* Book header */}
-      <div style={{ display: 'flex', gap: '20px', marginBottom: '24px', alignItems: 'flex-start' }}>
+      <div className="book-detail__header">
         {book.cover_url && (
           <img
             src={book.cover_url}
@@ -160,15 +160,15 @@ export default function BookDetail() {
             className="book-detail__cover"
           />
         )}
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px', marginBottom: '8px' }}>
+        <div className="book-detail__info">
+          <div className="book-detail__title-row">
             <div>
               <h1>{book.title}</h1>
               {book.author && (
                 <p style={{ fontSize: '1rem', color: 'var(--text-2)', marginBottom: '8px' }}>{book.author}</p>
               )}
             </div>
-            <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
+            <div className="book-detail__actions">
               <button className="btn btn--secondary btn--sm" onClick={() => setModal('edit')}>
                 <Pencil size={13} /> Edit
               </button>
@@ -228,7 +228,7 @@ export default function BookDetail() {
       )}
 
       {/* Notes section */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+      <div className="section-header section-header--tight">
         <h2 style={{ fontSize: '1rem' }}>Notes ({notes.length})</h2>
         <button className="btn btn--primary btn--sm" onClick={() => setModal('add-note')}>
           <Plus size={13} /> Add Note

--- a/frontend/src/pages/SeriesPage.tsx
+++ b/frontend/src/pages/SeriesPage.tsx
@@ -37,7 +37,7 @@ export default function SeriesPage() {
 
   return (
     <div className="page">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+      <div className="section-header">
         <h1 style={{ fontSize: '1.4rem', fontWeight: 700 }}>Series</h1>
       </div>
 

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -228,7 +228,7 @@ export default function Wishlist() {
                   ))}
                 </div>
               </div>
-              <div className="book-card__actions" style={{ display: 'flex', gap: '4px' }}>
+              <div className="book-card__actions">
                 <button
                   className="btn btn--icon btn--ghost"
                   onClick={e => handleMoveToLibrary(e, book)}

--- a/frontend/src/styles/_base.scss
+++ b/frontend/src/styles/_base.scss
@@ -15,7 +15,7 @@ html {
   --glass-border: none;
   --glass-shadow: none;
 
-  @media (max-width: 768px) {
+  @media (max-width: $bp-md) {
     font-size: 16px;
   }
 }

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -92,7 +92,7 @@
   option { background: $bg-elevated; }
 
   // 16px kills iOS Safari's auto-zoom-on-focus behavior
-  @media (max-width: 768px) {
+  @media (max-width: $bp-md) {
     font-size: 16px;
   }
 }
@@ -193,8 +193,12 @@
     &::placeholder { color: $text-4; }
     &:focus { outline: none; border-color: $border-light; }
 
-    @media (max-width: 768px) {
+    @media (max-width: $bp-md) {
       font-size: 16px;
+    }
+
+    @media (max-width: $bp-sm) {
+      max-width: none;
     }
   }
 }
@@ -229,6 +233,18 @@
   &--sm { max-width: 420px; }
   &--md { max-width: 560px; }
   &--lg { max-width: 720px; }
+
+  @media (max-width: $bp-md) {
+    &--sm, &--md, &--lg {
+      width: 100%;
+      max-width: none;
+    }
+    // iOS Safari counts the URL bar inside 100vh, so a 100vh-tall modal puts its
+    // submit button under the browser chrome where it cannot be tapped. dvh tracks
+    // the actually-visible viewport; the vh line stays as the pre-15.4 fallback.
+    max-height: calc(100vh - #{$space-6 * 2});
+    max-height: calc(100dvh - #{$space-6 * 2});
+  }
 
   &__header {
     display: flex;
@@ -319,6 +335,12 @@
   flex-direction: column;
   gap: 8px;
   pointer-events: none;
+
+  @media (max-width: $bp-sm) {
+    left: $space-3;
+    right: $space-3;
+    bottom: $space-3;
+  }
 }
 
 .toast {
@@ -334,6 +356,12 @@
   border: 1px solid;
   animation: slideInRight 200ms ease;
   backdrop-filter: var(--glass-blur);
+
+  @media (max-width: $bp-sm) {
+    min-width: 0;
+    max-width: none;
+    width: 100%;
+  }
 
   &--success { background: var(--toast-success-bg); border-color: var(--toast-success-border); color: $success; }
   &--error   { background: var(--toast-error-bg);   border-color: var(--toast-error-border);   color: $danger; }
@@ -485,7 +513,7 @@
   gap: $space-4;
   max-width: 100%;
 
-  @media (max-width: 480px) {
+  @media (max-width: $bp-sm) {
     grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
   }
 
@@ -592,7 +620,7 @@
   gap: $space-4;
   max-width: 100%;
 
-  @media (max-width: 480px) {
+  @media (max-width: $bp-sm) {
     grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   }
 }
@@ -693,6 +721,28 @@
       opacity: 1;
     }
   }
+
+  &__actions {
+    display: flex;
+    gap: $space-1;
+  }
+}
+
+// ── Section Header (heading + action button row) ──────────────────────────
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: $space-6;
+
+  &--tight {
+    margin-bottom: $space-4;
+  }
+
+  @media (max-width: $bp-sm) {
+    flex-wrap: wrap;
+    gap: $space-2;
+  }
 }
 
 // ── Dashboard Stats ───────────────────────────────────────────────────────
@@ -747,7 +797,7 @@
   gap: $space-4;
   margin-bottom: $space-6;
 
-  @media (max-width: 640px) { grid-template-columns: 1fr; }
+  @media (max-width: $bp-md) { grid-template-columns: 1fr; }
 }
 
 .chart-card {
@@ -925,6 +975,29 @@
     gap: $space-2;
     justify-content: flex-end;
   }
+
+  // Five grid columns (1.5fr 0.8fr 0.9fr 1fr auto) crush at phone widths.
+  // Stack instead: username on its own line, role/status/date wrap together,
+  // actions get their own full-width line.
+  @media (max-width: $bp-md) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: $space-2;
+
+    &--head { display: none; }
+
+    &__username {
+      flex: 1 0 100%;
+    }
+
+    &__actions {
+      flex: 1 0 100%;
+      justify-content: flex-start;
+      margin-top: $space-1;
+    }
+  }
 }
 
 // ── Cover Picker ──────────────────────────────────────────────────────────
@@ -992,6 +1065,41 @@
   &__url {
     font-size: 0.8125rem;
   }
+}
+
+// ── Book Detail Header ─────────────────────────────────────────────────────
+.book-detail__header {
+  display: flex;
+  gap: $space-5;
+  margin-bottom: $space-6;
+  align-items: flex-start;
+
+  @media (max-width: $bp-sm) {
+    flex-direction: column;
+  }
+}
+
+.book-detail__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.book-detail__title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: $space-4;
+  margin-bottom: $space-2;
+
+  @media (max-width: $bp-sm) {
+    flex-wrap: wrap;
+  }
+}
+
+.book-detail__actions {
+  display: flex;
+  gap: $space-2;
+  flex-shrink: 0;
 }
 
 // ── Book Detail Cover ─────────────────────────────────────────────────────
@@ -1167,7 +1275,7 @@
     border-radius: 3px;
     overflow: hidden;
 
-    @media (max-width: 480px) { display: none; }
+    @media (max-width: $bp-sm) { display: none; }
   }
 
   &__bar-fill {
@@ -1331,7 +1439,7 @@
   gap: $space-4;
   min-height: 520px;
 
-  @media (max-width: 760px) {
+  @media (max-width: $bp-md) {
     grid-template-columns: 1fr;
   }
 }
@@ -1618,6 +1726,11 @@
     transition: background $transition;
 
     &:hover, &:focus-visible { background: var(--danger); }
+
+    @media (pointer: coarse) {
+      width: 44px;
+      height: 44px;
+    }
   }
 
   &__error {
@@ -1762,7 +1875,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: $bp-md) {
   .scan-row {
     &__actions { width: 100%; justify-content: space-between; }
   }

--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -60,6 +60,12 @@ $sidebar-collapsed-width: 68px;
     color: $text-1;
     background: $bg-elevated;
   }
+
+  // iOS minimum touch target is 44px; the 28px visual size is fine for a mouse
+  @media (pointer: coarse) {
+    width: 44px;
+    height: 44px;
+  }
 }
 
 .sidebar__nav {
@@ -260,7 +266,7 @@ $sidebar-collapsed-width: 68px;
 }
 
 // ── Small screens: sidebar becomes a horizontal top bar ────────────────────
-@media (max-width: 768px) {
+@media (max-width: $bp-md) {
   .sidebar {
     position: static;
     width: 100%;
@@ -339,6 +345,10 @@ $sidebar-collapsed-width: 68px;
   backdrop-filter: var(--glass-blur);
   box-shadow: var(--glass-shadow, none);
   padding: $space-8 $space-6 $space-6;
+
+  @media (max-width: $bp-sm) {
+    max-width: none;
+  }
 
   &__brand {
     display: flex;

--- a/frontend/src/styles/_profile.scss
+++ b/frontend/src/styles/_profile.scss
@@ -29,7 +29,7 @@
   gap: $space-4;
   max-width: 100%;
 
-  @media (max-width: 480px) {
+  @media (max-width: $bp-sm) {
     grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
   }
 }

--- a/frontend/src/styles/_variables.scss
+++ b/frontend/src/styles/_variables.scss
@@ -49,6 +49,10 @@ $transition-slow: 250ms ease;
 // ── Sidebar ────────────────────────────────────────────────────────────────
 $sidebar-width: 200px;
 
+// ── Breakpoints ────────────────────────────────────────────────────────────
+$bp-sm: 480px; // small phone
+$bp-md: 768px; // phone landscape / small tablet; sidebar goes horizontal
+
 // ── Mixins ─────────────────────────────────────────────────────────────────
 @mixin flex-center {
   display: flex;


### PR DESCRIPTION
Targets 360–430px (iPhone 390px reference). **Desktop appearance is unchanged** — every new rule sits inside a media query or reproduces the previous inline value exactly.

## What was broken

| Fix | Impact at 390px |
|---|---|
| `.user-row` stacks below `$bp-md` | Was a 5-column grid with **no** mobile rule at all — every cell overlapped. Worst offender |
| `.toast` spans the viewport | 260px min-width pinned bottom-right meant success/error feedback was clipped off-screen entirely |
| `.messages-shell` stacks | Only broke at 760px, so both panes were unusable from 390–760 |
| Modals full-width + `dvh` height | iOS Safari counts the URL bar inside `100vh`, putting a long BookForm's save button under the browser chrome where it can't be tapped |
| Inline `style={{}}` → classes | Inline styles beat any stylesheet rule, so these blocks were invisible to a CSS-only fix |
| 44px targets under `pointer: coarse` | Sidebar collapse and scanner close were 28px |

## Breakpoint unification

The old 480 / 640 / 760 / 768 mix left dead gaps at 481–639, 641–759 and 761–767 where nothing applied. Now `$bp-sm: 480px` and `$bp-md: 768px`. Migrating 640 and 760 *up* to 768 widens their coverage — the safe direction. Capability queries (`pointer: coarse`, `hover: hover`) are left alone; they aren't size queries.

## Desktop safety

Each extracted class was checked against the `$space-*` scale so no value shifted: 20→`$space-5`, 24→`$space-6`, 16→`$space-4`, 8→`$space-2`, 4→`$space-1`. `min-width: 0` on the BookDetail info column was preserved — that's what stops long titles forcing horizontal overflow.

## Not verified

**No visual confirmation.** Browser device emulation is unavailable in the dev environment: window resize reports success but the viewport stays 1456px, and simulating a narrow width doesn't fire media queries. This is code-reasoned and build-verified (`npm run build` clean) only. First real check is on a phone after deploy.

## Known gap

Messages **stacks** on mobile rather than showing one pane at a time — you scroll past the whole thread list to reach a conversation. Functional but not good. Single-pane needs new state in `MessagesPage.tsx`, which is a component restructure rather than a styling fix, so it was left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd