### PR TITLE
chore(deploy): pin image for mobile responsive fixes

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:5cc7562596a4c308ca0b545365473749c9696e26a9539324049124764dc03b70
+          image: ghcr.io/mzakhar/vs-book-app@sha256:96a504b83cd43d9ea7f5938577b477b414c16ab016a7539a5f849431920e5f1f
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pins `k8s/base/deployment.yaml` to the GHCR digest built from 0eb7edc (#49, phone responsive fixes).

`sha256:5cc75625` → `sha256:96a504b8`

Flux reconciles `k8s/base` from Git, so this is what triggers the rollout — the `:main` image publish alone does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd