### PR TITLE
fix(ui): make the mobile sidebar an actual top bar

### DIFF
--- a/frontend/src/styles/_layout.scss
+++ b/frontend/src/styles/_layout.scss
@@ -267,10 +267,20 @@ $sidebar-collapsed-width: 68px;
 
 // ── Small screens: sidebar becomes a horizontal top bar ────────────────────
 @media (max-width: $bp-md) {
+  // `.layout` is `display: flex` with the default row direction. Taking the sidebar
+  // out of `position: fixed` below drops it back into that row as a flex item, so it
+  // lands BESIDE the content as a full-height band instead of above it — and the
+  // row-direction nav then spills sideways out of that band. Switching the axis is
+  // what actually makes the sidebar a top bar.
+  .layout {
+    flex-direction: column;
+  }
+
   .sidebar {
     position: static;
     width: 100%;
     height: auto;
+    flex-shrink: 0;
   }
 
   .sidebar__brand {
@@ -300,6 +310,9 @@ $sidebar-collapsed-width: 68px;
   .main-content,
   .layout--sidebar-collapsed .main-content {
     margin-left: 0;
+    // Stacked under the sidebar now, so a 100vh floor would push every page
+    // ~200px past the fold and leave a dead scroll region on all of them.
+    min-height: 0;
   }
 }
 
@@ -307,6 +320,11 @@ $sidebar-collapsed-width: 68px;
 .page {
   padding: $space-8;
   max-width: 1100px;
+
+  // 32px of padding on each side eats 64px of a 390px screen.
+  @media (max-width: $bp-md) {
+    padding: $space-4;
+  }
 }
 
 .page-header {


### PR DESCRIPTION
The sidebar has never worked on a phone — this is the bug behind "looks atrocious on mobile", and #49 did not fix it.

## Root cause

`.layout` is `display: flex` with the default **row** direction, and nothing ever changed that. The existing mobile rule takes `.sidebar` out of `position: fixed`, which drops it back into that row as a flex item — so it renders as a full-height band *beside* the content instead of a bar *above* it. `.sidebar__nav { flex-direction: row }` then makes the links spill sideways out of that band, and the page content gets pushed off to the right.

Switching the axis is what actually makes it a top bar:

```scss
@media (max-width: $bp-md) {
  .layout { flex-direction: column; }
}
```

## Also

- `.main-content` loses its `min-height: 100vh` on mobile — stacked under the sidebar it pushed every page ~200px past the fold, leaving a dead scroll region everywhere.
- `.page` padding 32px → 16px below `$bp-md`. 64px of horizontal padding on a 390px screen is a sixth of the viewport.

## Note

This was verified from a real phone screenshot, not inferred. The earlier audit reported the mobile sidebar as already handled; it was wrong, and #49 only renamed that block's breakpoint to a token without questioning whether it worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd