### PR TITLE
chore(deploy): pin image for mobile sidebar fix

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:96a504b83cd43d9ea7f5938577b477b414c16ab016a7539a5f849431920e5f1f
+          image: ghcr.io/mzakhar/vs-book-app@sha256:0d22e48a9760f6819c6b7cc2727ba058751d38d7b38efc9ed182909396c0e240
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pins to the digest built from 5d7ea64 (#51, mobile sidebar top bar).

`sha256:96a504b8` → `sha256:0d22e48a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd