### PR TITLE
fix(scan): attach the camera stream after the video mounts

### DIFF
--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -126,13 +126,10 @@ export default function BarcodeScanner({ onScan, onClose }: Props) {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
       streamRef.current = stream;
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-        await videoRef.current.play();
-      }
+      // The <video> is only rendered once `active` is true, so videoRef is still null
+      // here — attaching the stream at this point silently does nothing and leaves a
+      // black viewfinder. The effect below attaches it after the element mounts.
       setActive(true);
-      const { readBarcodes } = await loadZxing();
-      rafRef.current = requestAnimationFrame(() => decodeLoop(readBarcodes));
     } catch (err: any) {
       stop();
       if (err?.name === 'NotAllowedError') setError('denied');
@@ -142,6 +139,32 @@ export default function BarcodeScanner({ onScan, onClose }: Props) {
       startingRef.current = false;
     }
   };
+
+  // Runs after `active` flips true and the <video> has mounted, which is the earliest
+  // point videoRef is non-null. Starting the decode loop here too means it never spins
+  // against a video that has no stream.
+  useEffect(() => {
+    if (!active) return;
+    const video = videoRef.current;
+    const stream = streamRef.current;
+    if (!video || !stream) return;
+
+    let cancelled = false;
+    video.srcObject = stream;
+
+    (async () => {
+      try {
+        await video.play();
+        const { readBarcodes } = await loadZxing();
+        if (cancelled) return;
+        rafRef.current = requestAnimationFrame(() => decodeLoop(readBarcodes));
+      } catch {
+        if (!cancelled) setError('other');
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [active]);
 
   const handleManualSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -161,7 +184,7 @@ export default function BarcodeScanner({ onScan, onClose }: Props) {
       <div className="barcode-scanner__viewfinder">
         {active ? (
           <>
-            <video ref={videoRef} playsInline muted className="barcode-scanner__video" />
+            <video ref={videoRef} playsInline muted autoPlay className="barcode-scanner__video" />
             <div className={`barcode-scanner__flash${flash ? ' barcode-scanner__flash--active' : ''}`} />
             <div className="barcode-scanner__frame" />
           </>


### PR DESCRIPTION
Camera opened, permission prompt appeared, viewfinder stayed black. **Not device-specific** — this failed identically on the iPad; the Android report just surfaced it first.

## Root cause

The `<video>` is only rendered when `active` is true, but `start()` assigned the stream *before* setting it:

```js
streamRef.current = stream;
if (videoRef.current) {      // null — not mounted yet
  videoRef.current.srcObject = stream;
  await videoRef.current.play();
}
setActive(true);             // mounts a <video> with no srcObject
```

The `if` guard silently did nothing, so the element mounted without a source. `decodeLoop` then started anyway and spun on `video.readyState < 2` forever — burning CPU waiting for frames that could never arrive.

## Fix

Attach the stream in an effect keyed on `active`, which is the earliest point `videoRef` is non-null, and start the decode loop from there so it can never run against a source-less video. The effect's cleanup cancels in-flight startup if the scanner stops mid-init.

Also added `autoPlay`: `play()` is now called after an `await`, which breaks the user-gesture chain on some browsers, and `muted + playsInline + autoPlay` is permitted without one.

## Verification

Build clean. The decode path itself still has not been exercised against a real barcode — that needs the phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd