### PR TITLE
chore(deploy): pin image for scanner video fix

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/mzakhar/vs-book-app@sha256:0d22e48a9760f6819c6b7cc2727ba058751d38d7b38efc9ed182909396c0e240
+          image: ghcr.io/mzakhar/vs-book-app@sha256:a4871599eab6642d5ac8d0f890a3dbe3272a1cfb441f56e0e90f09592a11bcea
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV


### PR DESCRIPTION
Pins to the digest built from 69d6fbf (#53, camera stream attach fix).

`sha256:0d22e48a` → `sha256:a4871599`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd