### PR TITLE
feat(auth): replace password login with Google OIDC + email allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,10 @@ nothing is created, nothing is queued for approval.
   It must byte-match an authorized redirect URI on the Google OAuth client, so
   changing the base path means editing the GCP client too. Secrets:
   `k8s/base/oidc-secret.example.yaml`.
+- **GCP**: project `vs-book-app` (its own, not shared with the Gmail MCP project),
+  consent screen "V's Books", External / In production, OAuth client
+  `vs-book-app-web`. Scopes are `openid email` only — non-sensitive, so the app
+  needs no Google verification and the 100-user cap does not apply.
 - **`password_hash` is a dead column.** It stays `NOT NULL` and gets `''` because
   dropping it means rebuilding a table six foreign keys reference. Nothing reads it.
 - **`email` is the allowlist key** with a unique index; NULLs stay distinct, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,18 +55,27 @@ gh pr create --base main --fill && gh pr merge --squash --delete-branch
 - **Host**: `themachine`, Ubuntu, LAN IP `192.168.1.3` (static). SSH: `ssh mzakhar@192.168.1.3`.
 - **Orchestration**: k3s (v1.35.x) + Flux CD (GitOps). Flux runs on `themachine`, watches the separate `mzakhar/homelab-fleet` repo (`clusters/themachine/`) for the `GitRepository` + `Kustomization` that point back at this repo's `k8s/base`. So a merged digest pin in `main` is what actually triggers a rollout — a fresh `:main` image alone does not.
 - **Routing**: Traefik serves the app on the `/books/` subpath (StripPrefix middleware). Single replica; SQLite is node-local (local-path), so the workload is effectively node-pinned and cannot scale past one writer.
-- **URLs**: LAN `http://192.168.1.3/books/`; external `https://books.zakharhome.org/books/` (Cloudflare Tunnel). Backend health: `/api/health`.
+- **URLs**: LAN `http://192.168.1.3/books/`; external `https://books.zakharhome.org/books/` (Cloudflare Tunnel). Backend health is `/api/health` *inside the pod*; through Traefik it is `/books/api/health` — `localhost/api/health` returns `404 page not found`.
+- **Namespace**: the workload lives in the `vs-book-app` namespace, not `default`. `kubectl` without `-n vs-book-app` reports `deployments.apps "vs-book-app" not found`.
 - **Verify a rollout** (from `themachine` over SSH):
 
   ```bash
-  kubectl rollout status deploy/vs-book-app        # rollout progress
-  kubectl get pods -l app=vs-book-app -o wide       # running pod + node
-  kubectl get deploy vs-book-app -o jsonpath='{.spec.template.spec.containers[0].image}'  # live pinned digest
-  flux get kustomizations -A                         # Flux reconcile state
-  curl -s localhost/api/health                       # app health through Traefik
+  kubectl -n vs-book-app rollout status deploy/vs-book-app   # rollout progress
+  kubectl -n vs-book-app get pods -l app=vs-book-app -o wide # running pod + node
+  kubectl -n vs-book-app get deploy vs-book-app -o jsonpath='{.spec.template.spec.containers[0].image}'  # live pinned digest
+  flux get kustomizations -A                                 # Flux reconcile state
+  curl -s localhost/books/api/health                         # app health through Traefik
   ```
 
   Compare the live digest against `k8s/base/deployment.yaml` on `main` to confirm Flux has caught up.
+
+  Flux reconciles on its own interval, so a freshly merged pin may not be live yet. To apply
+  it immediately rather than waiting:
+
+  ```bash
+  flux reconcile source git vs-book-app
+  flux reconcile kustomization vs-book-app
+  ```
 
 ## Handling `[Feedback]` issues
 
@@ -123,6 +132,45 @@ Three CSS themes (`dark`, `light`, `purple`) defined as CSS custom properties in
 - `notes(id, book_id, content, created_at, updated_at)` — cascades delete from books
 
 WAL mode and foreign keys are enabled on every connection.
+
+## Authentication — Google OIDC + allowlist
+
+There are no passwords. Identity comes from Google; authorization comes from a row
+in `users` with a matching `email`. An unrecognised Google account is rejected —
+nothing is created, nothing is queued for approval.
+
+- **Flow** (`backend/src/oidc.ts`, `backend/src/routes/auth.ts`): `GET /api/auth/login`
+  mints state + PKCE into a 10-minute `book_app_oidc` cookie and 302s to Google;
+  `GET /api/auth/callback` verifies state, exchanges the code, validates the
+  `id_token` claims, looks the email up in `users`, then creates the *existing*
+  session-cookie session. The `sessions` table, `requireAuth`, and the 30-day
+  sliding cookie are unchanged from the password era — only the proof of identity
+  is different.
+- **The `id_token` signature is not verified.** It arrives on our own TLS
+  connection to Google's token endpoint in response to a code we minted, which is
+  the case OIDC Core 3.1.3.7 exempts. Never extend `decodeIdToken` to tokens that
+  came from a browser.
+- **`APP_BASE_URL` drives the redirect URI** (`<APP_BASE_URL>/api/auth/callback`).
+  It must byte-match an authorized redirect URI on the Google OAuth client, so
+  changing the base path means editing the GCP client too. Secrets:
+  `k8s/base/oidc-secret.example.yaml`.
+- **`password_hash` is a dead column.** It stays `NOT NULL` and gets `''` because
+  dropping it means rebuilding a table six foreign keys reference. Nothing reads it.
+- **`email` is the allowlist key** with a unique index; NULLs stay distinct, so
+  pre-OIDC users simply cannot sign in until an admin sets their address on the
+  Users page. `ADMIN_EMAIL` is the bootstrap: it seeds the first admin on an empty
+  DB, or backfills the first admin's NULL email on an existing one. It never
+  overwrites an address that is already set.
+- **Local dev never talks to Google** (no public HTTPS callback). Set
+  `DEV_LOGIN_EMAIL` to an active user's address and use the "Dev sign in" button;
+  `POST /api/auth/dev-login` 404s when `NODE_ENV=production` or the var is unset.
+- **The LAN URL can no longer sign anyone in.** `http://192.168.1.3/books/` drops the
+  `secure` state cookie and then hands off to the public host, so the callback fails
+  with `?error=state`. Sign in at `https://books.zakharhome.org/books/`; the LAN
+  address still works for an already-authenticated browser.
+- Deep links are not preserved through sign-in — every successful callback lands
+  on `/books/`.
+- Self-check for the pure half: `cd backend && npx ts-node src/oidc.check.ts`.
 
 ## Barcode scanning
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "@opentelemetry/sdk-node": "^0.220.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.43.0",
-        "bcryptjs": "^3.0.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -26,7 +25,6 @@
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
-        "@types/bcryptjs": "^2.4.6",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -1750,13 +1748,6 @@
       "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
       "license": "MIT"
     },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2181,15 +2172,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
-      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
-      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,6 @@
     "@opentelemetry/sdk-node": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
-    "bcryptjs": "^3.0.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.18.2",
@@ -25,7 +24,6 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -237,6 +237,22 @@ export async function getDb(): Promise<Database> {
     );
   }
 
+  // Accounts created before OIDC were often registered under the user's own email
+  // address as the username. Promote those to the allowlist so they aren't locked
+  // out. Only touches NULL emails, and only usernames that parse as an address.
+  try {
+    await _db.run(
+      `UPDATE users SET email = lower(trim(username))
+       WHERE email IS NULL
+         AND username LIKE '%_@_%._%'
+         AND username NOT LIKE '% %'`
+    );
+  } catch (e) {
+    // Unique-index collision means two accounts share an address; leave both NULL
+    // and let an admin sort it out on the Users page.
+    console.warn('username→email backfill skipped:', (e as Error).message);
+  }
+
   // 6. Backfill ownership of pre-existing books/series to the first admin
   const admin: any = await _db.get(`SELECT id FROM users WHERE role = 'admin' ORDER BY id ASC LIMIT 1`);
   if (admin) {

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -2,7 +2,6 @@ import { open, Database } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import fs from 'fs/promises';
 import path from 'path';
-import bcrypt from 'bcryptjs';
 
 let _db: Database | null = null;
 
@@ -142,10 +141,16 @@ export async function getDb(): Promise<Database> {
     `ALTER TABLE users ADD COLUMN favorite_book_id INTEGER REFERENCES books(id) ON DELETE SET NULL`,
     `ALTER TABLE books ADD COLUMN is_favorite INTEGER DEFAULT 0`,
     `ALTER TABLE books ADD COLUMN isbn TEXT`,
+    `ALTER TABLE users ADD COLUMN email TEXT`,
+    `ALTER TABLE users ADD COLUMN google_sub TEXT`,
   ];
   for (const sql of migrations) {
     try { await _db.run(sql); } catch { /* column already exists */ }
   }
+
+  // Email is the Google OIDC allowlist key. NULLs stay distinct in SQLite unique
+  // indexes, so users predating OIDC (email IS NULL) don't collide.
+  await _db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email)`);
 
   // 3. Migrate existing genre data to book_genres if book_genres is empty
   try {
@@ -206,20 +211,30 @@ export async function getDb(): Promise<Database> {
     }
   }
 
-  // 5. Seed admin user if none exist
+  // 5. Bootstrap the first admin from ADMIN_EMAIL.
+  // password_hash survives as a NOT NULL column only because dropping it means
+  // rebuilding a table six foreign keys point at. Nothing reads it any more.
+  // ponytail: dead column, drop it if users ever gets rebuilt for another reason.
+  const adminEmail = (process.env.ADMIN_EMAIL || '').trim().toLowerCase();
   const userCount: any = await _db.get('SELECT COUNT(*) as c FROM users');
   if (userCount && userCount.c === 0) {
-    const adminUsername = process.env.ADMIN_USERNAME;
-    const adminPassword = process.env.ADMIN_PASSWORD;
-    if (adminUsername && adminPassword) {
-      const hash = await bcrypt.hash(adminPassword, 12);
+    if (adminEmail) {
       await _db.run(
-        `INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'admin')`,
-        adminUsername, hash
+        `INSERT INTO users (username, password_hash, email, role) VALUES (?, '', ?, 'admin')`,
+        adminEmail.split('@')[0], adminEmail
       );
     } else {
-      console.warn('no users exist and ADMIN_USERNAME/ADMIN_PASSWORD not set — nobody can log in');
+      console.warn('no users exist and ADMIN_EMAIL not set — nobody can log in');
     }
+  } else if (adminEmail) {
+    // Pre-OIDC database: hand the first admin an address so they can sign in and
+    // fill in everyone else's from the Users page. Never overwrites a set email.
+    await _db.run(
+      `UPDATE users SET email = ?
+       WHERE email IS NULL
+         AND id = (SELECT id FROM users WHERE role = 'admin' ORDER BY id ASC LIMIT 1)`,
+      adminEmail
+    );
   }
 
   // 6. Backfill ownership of pre-existing books/series to the first admin

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,13 +30,15 @@ if (!IS_PROD) {
 app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());
 
+// Google does the credential rate limiting now; this only caps how fast one IP
+// can burn callbacks and mint sessions.
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  limit: 10,
+  limit: 20,
   standardHeaders: true,
 });
 
-app.use('/api/auth/login', loginLimiter);
+app.use('/api/auth/callback', loginLimiter);
 app.use('/api/auth', authRouter);
 app.use('/api/users', requireAuth, usersRouter);
 app.use('/api/books', requireAuth, booksRouter);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -6,7 +6,7 @@ import { getDb } from '../database';
 declare global {
   namespace Express {
     interface Request {
-      user?: { id: number; username: string; role: 'admin' | 'user' };
+      user?: { id: number; username: string; email: string | null; role: 'admin' | 'user' };
     }
   }
 }
@@ -61,7 +61,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   const tokenHash = hashToken(token);
 
   const row: any = await db.get(
-    `SELECT s.token_hash, s.expires_at, u.id as user_id, u.username, u.role, u.is_active
+    `SELECT s.token_hash, s.expires_at, u.id as user_id, u.username, u.email, u.role, u.is_active
      FROM sessions s JOIN users u ON u.id = s.user_id
      WHERE s.token_hash = ?`,
     tokenHash
@@ -82,7 +82,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     return;
   }
 
-  req.user = { id: row.user_id, username: row.username, role: row.role };
+  req.user = { id: row.user_id, username: row.username, email: row.email ?? null, role: row.role };
 
   // Sliding renewal: extend if within 15 days of expiry
   if (expiresAt - Date.now() < RENEWAL_THRESHOLD_MS) {

--- a/backend/src/oidc.check.ts
+++ b/backend/src/oidc.check.ts
@@ -1,0 +1,96 @@
+/**
+ * Self-check for the pure half of the OIDC flow.
+ * Run: npx ts-node backend/src/oidc.check.ts
+ */
+import assert from 'assert';
+import {
+  buildAuthUrl,
+  decodeIdToken,
+  newPkce,
+  normalizeEmail,
+  validateClaims,
+  OidcConfig,
+} from './oidc';
+
+const cfg: OidcConfig = {
+  clientId: 'cid.apps.googleusercontent.com',
+  clientSecret: 'secret',
+  baseUrl: 'https://books.example.org/books',
+  redirectUri: 'https://books.example.org/books/api/auth/callback',
+};
+
+const NOW = 1_700_000_000_000;
+const FUTURE = Math.floor(NOW / 1000) + 600;
+const PAST = Math.floor(NOW / 1000) - 600;
+
+function idTokenFor(payload: object): string {
+  const seg = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `header.${seg}.signature`;
+}
+
+const goodClaims = {
+  iss: 'https://accounts.google.com',
+  aud: cfg.clientId,
+  exp: FUTURE,
+  sub: '110123',
+  email: '  Reader@Gmail.com ',
+  email_verified: true,
+};
+
+// --- auth url ---
+{
+  const url = new URL(buildAuthUrl(cfg, 'st4te', 'ch4llenge'));
+  assert.strictEqual(url.origin + url.pathname, 'https://accounts.google.com/o/oauth2/v2/auth');
+  assert.strictEqual(url.searchParams.get('client_id'), cfg.clientId);
+  assert.strictEqual(url.searchParams.get('redirect_uri'), cfg.redirectUri);
+  assert.strictEqual(url.searchParams.get('response_type'), 'code');
+  assert.strictEqual(url.searchParams.get('code_challenge_method'), 'S256');
+  assert.strictEqual(url.searchParams.get('state'), 'st4te');
+}
+
+// --- pkce ---
+{
+  const a = newPkce();
+  const b = newPkce();
+  assert.notStrictEqual(a.verifier, b.verifier, 'verifier must not repeat');
+  assert.ok(!/[+/=]/.test(a.verifier + a.challenge), 'must be base64url, not base64');
+}
+
+// --- decode ---
+assert.strictEqual(decodeIdToken('not-a-jwt'), null);
+assert.strictEqual(decodeIdToken('a.!!!not-base64-json!!!.c'), null);
+assert.deepStrictEqual(decodeIdToken(idTokenFor({ sub: 'x' })), { sub: 'x' });
+
+// --- claim validation ---
+{
+  const ok = validateClaims(decodeIdToken(idTokenFor(goodClaims)), cfg.clientId, NOW);
+  assert.ok(ok.ok);
+  assert.strictEqual(ok.email, 'reader@gmail.com', 'email normalised to lowercase');
+  assert.strictEqual(ok.sub, '110123');
+}
+
+const rejects: Array<[string, object | null]> = [
+  ['malformed', null],
+  ['bad issuer', { ...goodClaims, iss: 'https://evil.example' }],
+  ['bad audience', { ...goodClaims, aud: 'someone-elses-client-id' }],
+  ['expired', { ...goodClaims, exp: PAST }],
+  ['no exp', { ...goodClaims, exp: undefined }],
+  ['no sub', { ...goodClaims, sub: undefined }],
+  ['unverified email', { ...goodClaims, email_verified: false }],
+  ['missing email_verified', { ...goodClaims, email_verified: undefined }],
+  ['no email', { ...goodClaims, email: undefined }],
+];
+for (const [label, claims] of rejects) {
+  const result = validateClaims(claims as any, cfg.clientId, NOW);
+  assert.strictEqual(result.ok, false, `expected rejection: ${label}`);
+}
+
+// --- email normalisation (also the admin allowlist input path) ---
+assert.strictEqual(normalizeEmail('  A.B@Gmail.COM '), 'a.b@gmail.com');
+assert.strictEqual(normalizeEmail('nope'), null);
+assert.strictEqual(normalizeEmail('no@domain'), null);
+assert.strictEqual(normalizeEmail('two @spaces.com'), null);
+assert.strictEqual(normalizeEmail(42), null);
+assert.strictEqual(normalizeEmail('x'.repeat(250) + '@gmail.com'), null);
+
+console.log('oidc.check: all assertions passed');

--- a/backend/src/oidc.ts
+++ b/backend/src/oidc.ts
@@ -1,0 +1,127 @@
+import crypto from 'crypto';
+
+// Google's OIDC endpoints are stable and documented; discovery adds a network
+// round trip per login for values that have not changed in a decade.
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+const VALID_ISSUERS = new Set(['https://accounts.google.com', 'accounts.google.com']);
+
+export interface OidcConfig {
+  clientId: string;
+  clientSecret: string;
+  /** Public origin + base path, no trailing slash — e.g. https://books.example.org/books */
+  baseUrl: string;
+  redirectUri: string;
+}
+
+/** Null when the app has not been given Google credentials — callers return 503. */
+export function oidcConfig(): OidcConfig | null {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const baseUrl = (process.env.APP_BASE_URL || '').replace(/\/+$/, '');
+  if (!clientId || !clientSecret || !baseUrl) return null;
+  return { clientId, clientSecret, baseUrl, redirectUri: `${baseUrl}/api/auth/callback` };
+}
+
+export function newPkce(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+export function buildAuthUrl(cfg: OidcConfig, state: string, challenge: string): string {
+  const params = new URLSearchParams({
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    response_type: 'code',
+    scope: 'openid email',
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    prompt: 'select_account',
+  });
+  return `${GOOGLE_AUTH_URL}?${params}`;
+}
+
+export interface IdTokenClaims {
+  iss?: string;
+  aud?: string;
+  exp?: number;
+  sub?: string;
+  email?: string;
+  email_verified?: boolean;
+}
+
+/**
+ * Reads the id_token payload without verifying its signature. Safe here and only
+ * here: the token came back on our own TLS connection to Google's token endpoint,
+ * in response to a code we minted (OIDC Core 3.1.3.7, clause 6). Never call this
+ * on a token that arrived from a browser.
+ */
+export function decodeIdToken(idToken: string): IdTokenClaims | null {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export type ClaimCheck =
+  | { ok: true; email: string; sub: string }
+  | { ok: false; reason: string };
+
+export function validateClaims(
+  claims: IdTokenClaims | null,
+  clientId: string,
+  nowMs: number
+): ClaimCheck {
+  if (!claims) return { ok: false, reason: 'malformed id_token' };
+  if (!claims.iss || !VALID_ISSUERS.has(claims.iss)) return { ok: false, reason: 'bad issuer' };
+  if (claims.aud !== clientId) return { ok: false, reason: 'bad audience' };
+  if (typeof claims.exp !== 'number' || claims.exp * 1000 <= nowMs) return { ok: false, reason: 'expired' };
+  if (!claims.sub) return { ok: false, reason: 'missing sub' };
+  if (claims.email_verified !== true) return { ok: false, reason: 'email not verified' };
+  const email = normalizeEmail(claims.email);
+  if (!email) return { ok: false, reason: 'missing or invalid email' };
+  return { ok: true, email, sub: claims.sub };
+}
+
+/** Lowercased + trimmed, or null if it isn't shaped like an address. */
+export function normalizeEmail(input: unknown): string | null {
+  if (typeof input !== 'string') return null;
+  const email = input.trim().toLowerCase();
+  if (email.length > 254) return null;
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return null;
+  return email;
+}
+
+/** Returns the id_token, or null if the exchange failed. */
+export async function exchangeCode(
+  cfg: OidcConfig,
+  code: string,
+  verifier: string
+): Promise<string | null> {
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: cfg.clientId,
+      client_secret: cfg.clientSecret,
+      redirect_uri: cfg.redirectUri,
+      grant_type: 'authorization_code',
+      code_verifier: verifier,
+    }),
+  });
+
+  if (!res.ok) {
+    console.error('google token exchange failed', res.status, await res.text());
+    return null;
+  }
+
+  const body: any = await res.json();
+  return typeof body.id_token === 'string' ? body.id_token : null;
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,35 +1,104 @@
 import { Router, Request, Response } from 'express';
-import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 import { getDb } from '../database';
 import { asyncHandler } from '../asyncHandler';
 import { createSession, destroySession, requireAuth } from '../middleware/auth';
+import {
+  buildAuthUrl,
+  decodeIdToken,
+  exchangeCode,
+  newPkce,
+  oidcConfig,
+  validateClaims,
+} from '../oidc';
 
 const router = Router();
 
-// Fixed dummy hash so login timing is uniform whether or not the username exists.
-const DUMMY_HASH = '$2a$12$C6UzMDM.H6dfI/f/IKcEeOa8i1V6dGmuVs.dRnO2XM.pP3Bq2mkci';
+const IS_PROD = process.env.NODE_ENV === 'production';
+const OIDC_COOKIE = 'book_app_oidc';
+const OIDC_TTL_MS = 10 * 60 * 1000;
 
-router.post('/login', asyncHandler(async (req: Request, res: Response) => {
-  const { username, password } = req.body;
-  if (!username || !password) {
-    return res.status(401).json({ error: 'Invalid username or password' });
+// GET, not POST: this is a top-level browser navigation to Google.
+router.get('/login', asyncHandler(async (_req: Request, res: Response) => {
+  const cfg = oidcConfig();
+  if (!cfg) return res.status(503).send('Google sign-in is not configured.');
+
+  const state = crypto.randomBytes(32).toString('hex');
+  const { verifier, challenge } = newPkce();
+
+  // sameSite 'lax' is required — the callback arrives as a cross-site top-level
+  // navigation from accounts.google.com, and 'strict' would drop this cookie.
+  res.cookie(OIDC_COOKIE, JSON.stringify({ state, verifier }), {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: IS_PROD,
+    maxAge: OIDC_TTL_MS,
+    path: '/',
+  });
+
+  res.redirect(buildAuthUrl(cfg, state, challenge));
+}));
+
+router.get('/callback', asyncHandler(async (req: Request, res: Response) => {
+  const cfg = oidcConfig();
+  if (!cfg) return res.status(503).send('Google sign-in is not configured.');
+
+  const raw = req.cookies?.[OIDC_COOKIE];
+  res.clearCookie(OIDC_COOKIE, { path: '/' });
+
+  // Every failure lands back on the login page with a code the SPA turns into copy.
+  const fail = (reason: string) => res.redirect(`${cfg.baseUrl}/login?error=${reason}`);
+
+  if (req.query.error) return fail('denied');
+
+  let stored: { state?: string; verifier?: string } = {};
+  try { stored = JSON.parse(raw || '{}'); } catch { /* malformed cookie — treated as missing */ }
+
+  const code = typeof req.query.code === 'string' ? req.query.code : '';
+  if (!stored.state || !stored.verifier || !code || req.query.state !== stored.state) {
+    return fail('state');
   }
 
+  const idToken = await exchangeCode(cfg, code, stored.verifier);
+  if (!idToken) return fail('exchange');
+
+  const claims = validateClaims(decodeIdToken(idToken), cfg.clientId, Date.now());
+  if (!claims.ok) {
+    console.warn('rejected google id_token:', claims.reason);
+    return fail('token');
+  }
+
+  // The allowlist: an admin must have already created a user with this address.
   const db = await getDb();
   const user: any = await db.get(
-    `SELECT * FROM users WHERE username = ? AND is_active = 1`,
-    username
+    `SELECT id, google_sub FROM users WHERE email = ? AND is_active = 1`,
+    claims.email
   );
+  if (!user) return fail('not_authorized');
 
-  const hashToCompare = user ? user.password_hash : DUMMY_HASH;
-  const valid = await bcrypt.compare(password, hashToCompare);
-
-  if (!user || !valid) {
-    return res.status(401).json({ error: 'Invalid username or password' });
+  if (!user.google_sub) {
+    await db.run(`UPDATE users SET google_sub = ? WHERE id = ?`, claims.sub, user.id);
   }
 
   await createSession(db, user.id, res);
-  res.json({ id: user.id, username: user.username, role: user.role });
+  res.redirect(`${cfg.baseUrl}/`);
+}));
+
+// Dev-only shortcut so `npm run dev` doesn't need a public HTTPS callback.
+// 404s in production and whenever DEV_LOGIN_EMAIL is unset.
+router.post('/dev-login', asyncHandler(async (_req: Request, res: Response) => {
+  const email = (process.env.DEV_LOGIN_EMAIL || '').trim().toLowerCase();
+  if (IS_PROD || !email) return res.status(404).json({ error: 'not found' });
+
+  const db = await getDb();
+  const user: any = await db.get(
+    `SELECT id, username, email, role FROM users WHERE email = ? AND is_active = 1`,
+    email
+  );
+  if (!user) return res.status(401).json({ error: 'DEV_LOGIN_EMAIL matches no active user' });
+
+  await createSession(db, user.id, res);
+  res.json(user);
 }));
 
 router.post('/logout', asyncHandler(async (req: Request, res: Response) => {
@@ -39,7 +108,12 @@ router.post('/logout', asyncHandler(async (req: Request, res: Response) => {
 }));
 
 router.get('/me', requireAuth, asyncHandler(async (req: Request, res: Response) => {
-  res.json({ id: req.user!.id, username: req.user!.username, role: req.user!.role });
+  res.json({
+    id: req.user!.id,
+    username: req.user!.username,
+    email: req.user!.email,
+    role: req.user!.role,
+  });
 }));
 
 export default router;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,9 +1,9 @@
 import { Router, Request, Response } from 'express';
-import bcrypt from 'bcryptjs';
 import { Database } from 'sqlite';
 import { getDb } from '../database';
 import { asyncHandler } from '../asyncHandler';
 import { requireAdmin } from '../middleware/auth';
+import { normalizeEmail } from '../oidc';
 
 const router = Router();
 
@@ -100,29 +100,40 @@ router.get('/', asyncHandler(async (_req: Request, res: Response) => {
 router.get('/admin', requireAdmin, asyncHandler(async (_req: Request, res: Response) => {
   const db = await getDb();
   const users = await db.all(
-    `SELECT id, username, role, is_active, created_at FROM users ORDER BY id ASC`
+    `SELECT id, username, email, role, is_active, created_at FROM users ORDER BY id ASC`
   );
   res.json(users);
 }));
 
+// Creating a user IS the allowlist entry — the address must match the Google
+// account they sign in with, exactly.
 router.post('/', requireAdmin, asyncHandler(async (req: Request, res: Response) => {
-  const { username, password, role } = req.body;
+  const { username, email, role } = req.body;
   if (!username || !username.trim()) return res.status(400).json({ error: 'Username is required' });
-  if (!password || password.length < 8) return res.status(400).json({ error: 'Password must be at least 8 characters' });
+
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return res.status(400).json({ error: 'A valid email address is required' });
+
   const roleToUse = role === 'admin' ? 'admin' : 'user';
 
   const db = await getDb();
-  const existing = await db.get(`SELECT id FROM users WHERE username = ?`, username.trim());
-  if (existing) return res.status(409).json({ error: 'Username already exists' });
+  const clash = await db.get(
+    `SELECT username FROM users WHERE username = ? OR email = ?`,
+    username.trim(), normalizedEmail
+  );
+  if (clash) {
+    return res.status(409).json({
+      error: clash.username === username.trim() ? 'Username already exists' : 'Email already exists',
+    });
+  }
 
-  const hash = await bcrypt.hash(password, 12);
   const result = await db.run(
-    `INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)`,
-    username.trim(), hash, roleToUse
+    `INSERT INTO users (username, password_hash, email, role) VALUES (?, '', ?, ?)`,
+    username.trim(), normalizedEmail, roleToUse
   );
 
   const user = await db.get(
-    `SELECT id, username, role, is_active, created_at FROM users WHERE id = ?`,
+    `SELECT id, username, email, role, is_active, created_at FROM users WHERE id = ?`,
     result.lastID
   );
   res.status(201).json(user);
@@ -180,7 +191,7 @@ router.put('/:id', requireAdmin, asyncHandler(async (req: Request, res: Response
   const existing = await db.get(`SELECT * FROM users WHERE id = ?`, req.params.id);
   if (!existing) return res.status(404).json({ error: 'User not found' });
 
-  const { password, is_active, role } = req.body;
+  const { email, is_active, role } = req.body;
 
   // Lockout guard: an admin cannot deactivate or demote their own account.
   const isSelf = Number(req.params.id) === req.user!.id;
@@ -188,10 +199,15 @@ router.put('/:id', requireAdmin, asyncHandler(async (req: Request, res: Response
     return res.status(400).json({ error: 'Cannot change your own active status or role' });
   }
 
-  if (password !== undefined) {
-    if (!password || password.length < 8) return res.status(400).json({ error: 'Password must be at least 8 characters' });
-    const hash = await bcrypt.hash(password, 12);
-    await db.run(`UPDATE users SET password_hash = ? WHERE id = ?`, hash, req.params.id);
+  if (email !== undefined) {
+    const normalizedEmail = normalizeEmail(email);
+    if (!normalizedEmail) return res.status(400).json({ error: 'Invalid email address' });
+    const clash = await db.get(
+      `SELECT id FROM users WHERE email = ? AND id != ?`, normalizedEmail, req.params.id
+    );
+    if (clash) return res.status(409).json({ error: 'Email already exists' });
+    await db.run(`UPDATE users SET email = ? WHERE id = ?`, normalizedEmail, req.params.id);
+    // Re-pointing the allowlist entry must not leave the old owner signed in.
     await db.run(`DELETE FROM sessions WHERE user_id = ?`, req.params.id);
   }
 
@@ -205,7 +221,7 @@ router.put('/:id', requireAdmin, asyncHandler(async (req: Request, res: Response
   }
 
   const user = await db.get(
-    `SELECT id, username, role, is_active, created_at FROM users WHERE id = ?`,
+    `SELECT id, username, email, role, is_active, created_at FROM users WHERE id = ?`,
     req.params.id
   );
   res.json(user);

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -43,8 +43,10 @@ api.interceptors.response.use(
 );
 
 // Auth
-export const login = (username: string, password: string) =>
-  api.post<AuthUser>('/auth/login', { username, password }).then(r => r.data);
+// Sign-in itself is a full-page redirect to /api/auth/login (see LoginPage), not
+// an XHR — the browser has to follow Google's 302 chain.
+export const devLogin = () =>
+  api.post<AuthUser>('/auth/dev-login').then(r => r.data);
 export const logout = () =>
   api.post('/auth/logout');
 export const getMe = () =>
@@ -53,9 +55,9 @@ export const getMe = () =>
 // Users (admin)
 export const getUsers = () =>
   api.get<ManagedUser[]>('/users/admin').then(r => r.data);
-export const createUser = (data: { username: string; password: string; role?: UserRole }) =>
+export const createUser = (data: { username: string; email: string; role?: UserRole }) =>
   api.post<ManagedUser>('/users', data).then(r => r.data);
-export const updateUser = (id: number, data: Partial<{ password: string; is_active: number; role: UserRole }>) =>
+export const updateUser = (id: number, data: Partial<{ email: string; is_active: number; role: UserRole }>) =>
   api.put<ManagedUser>(`/users/${id}`, data).then(r => r.data);
 export const deleteUser = (id: number) =>
   api.delete(`/users/${id}`);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,18 +1,19 @@
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from 'react';
-import { getMe, login as apiLogin, logout as apiLogout, registerUnauthorizedHandler, unregisterUnauthorizedHandler } from '../api';
+import { getMe, devLogin as apiDevLogin, logout as apiLogout, registerUnauthorizedHandler, unregisterUnauthorizedHandler } from '../api';
 import type { AuthUser } from '../types';
 
 interface AuthCtx {
   user: AuthUser | null;
   loading: boolean;
-  login: (username: string, password: string) => Promise<string | undefined>;
+  /** Dev-only bypass; the backend 404s this in production. */
+  devLogin: () => Promise<string | undefined>;
   logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthCtx>({
   user: null,
   loading: true,
-  login: async () => undefined,
+  devLogin: async () => undefined,
   logout: async () => {},
 });
 
@@ -37,14 +38,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .finally(() => setLoading(false));
   }, []);
 
-  const login = useCallback(async (username: string, password: string) => {
+  const devLogin = useCallback(async () => {
     try {
-      const u = await apiLogin(username, password);
-      setUser(u);
+      setUser(await apiDevLogin());
       return undefined;
     } catch (err: any) {
-      if (err?.response?.status === 429) return 'Too many attempts, try later.';
-      return err?.response?.data?.error || 'Invalid username or password';
+      return err?.response?.data?.error || 'Dev login is not available.';
     }
   }, []);
 
@@ -57,7 +56,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, devLogin, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,34 +1,33 @@
-import { useState, FormEvent } from 'react';
-import { useLocation, Navigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useLocation, useSearchParams, Navigate } from 'react-router-dom';
 import { BookOpen } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 
-export default function LoginPage() {
-  const { user, loading, login } = useAuth();
-  const location = useLocation();
+// BASE_URL is '/books/', so this resolves to the path Traefik strips before the
+// request reaches Express. Full navigation, not fetch — Google's 302 needs the browser.
+const GOOGLE_LOGIN_URL = `${import.meta.env.BASE_URL}api/auth/login`;
 
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [submitting, setSubmitting] = useState(false);
+const ERROR_COPY: Record<string, string> = {
+  not_authorized: "That Google account isn't on the list. Ask an admin to add it.",
+  denied: 'Sign-in was cancelled.',
+  state: 'Sign-in took too long. Try again.',
+  exchange: "Couldn't reach Google. Try again.",
+  token: "Google's response was rejected. Try again.",
+};
+
+export default function LoginPage() {
+  const { user, loading, devLogin } = useAuth();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const [devError, setDevError] = useState('');
 
   if (!loading && user) {
     const from = (location.state as { from?: { pathname: string; search: string } })?.from;
     return <Navigate to={from ? `${from.pathname}${from.search}` : '/'} replace />;
   }
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!username.trim() || !password) return;
-    setSubmitting(true);
-    setError('');
-    try {
-      const err = await login(username.trim(), password);
-      if (err) setError(err);
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const errorCode = searchParams.get('error');
+  const error = devError || (errorCode ? ERROR_COPY[errorCode] || 'Sign-in failed. Try again.' : '');
 
   return (
     <div className="auth-page">
@@ -38,35 +37,32 @@ export default function LoginPage() {
           <span>V&apos;s Books</span>
         </div>
         <h1 className="auth-card__title">Sign in</h1>
-        <form onSubmit={handleSubmit}>
-          {error && <p className="form-error">{error}</p>}
-          <div className="form-group">
-            <label className="form-label" htmlFor="username">Username</label>
-            <input
-              id="username"
-              className="form-input"
-              value={username}
-              onChange={e => setUsername(e.target.value)}
-              autoFocus
-              autoComplete="username"
-            />
-          </div>
-          <div className="form-group">
-            <label className="form-label" htmlFor="password">Password</label>
-            <input
-              id="password"
-              type="password"
-              className="form-input"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              autoComplete="current-password"
-            />
-          </div>
-          <button type="submit" className="btn btn--primary auth-card__submit" disabled={submitting}>
-            {submitting ? 'Signing in…' : 'Sign in'}
+        {error && <p className="form-error">{error}</p>}
+        <a className="btn btn--primary auth-card__submit" href={GOOGLE_LOGIN_URL}>
+          <GoogleMark />
+          Continue with Google
+        </a>
+        {import.meta.env.DEV && (
+          <button
+            className="btn btn--secondary auth-card__submit"
+            style={{ marginTop: 8 }}
+            onClick={async () => setDevError((await devLogin()) || '')}
+          >
+            Dev sign in
           </button>
-        </form>
+        )}
       </div>
     </div>
+  );
+}
+
+function GoogleMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+      <path fill="#4285F4" d="M45.1 24.5c0-1.6-.1-3.2-.4-4.7H24v8.9h11.8a10 10 0 0 1-4.4 6.6v5.5h7.1c4.2-3.8 6.6-9.5 6.6-16.3z" />
+      <path fill="#34A853" d="M24 46c6 0 11-2 14.6-5.3l-7.1-5.5c-2 1.3-4.5 2.1-7.5 2.1-5.8 0-10.6-3.9-12.4-9.1H4.3v5.7A22 22 0 0 0 24 46z" />
+      <path fill="#FBBC05" d="M11.6 28.2a13.2 13.2 0 0 1 0-8.4v-5.7H4.3a22 22 0 0 0 0 19.8l7.3-5.7z" />
+      <path fill="#EA4335" d="M24 10.8c3.3 0 6.2 1.1 8.5 3.3l6.3-6.3C35 4.1 30 2 24 2A22 22 0 0 0 4.3 14.1l7.3 5.7c1.8-5.2 6.6-9 12.4-9z" />
+    </svg>
   );
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, FormEvent } from 'react';
-import { Plus, KeyRound, Ban, CheckCircle2, Trash2, ShieldAlert } from 'lucide-react';
+import { Plus, Mail, Ban, CheckCircle2, Trash2, ShieldAlert } from 'lucide-react';
 import { getUsers, createUser, updateUser, deleteUser } from '../api';
 import type { ManagedUser, UserRole } from '../types';
 import { useAuth } from '../context/AuthContext';
@@ -14,15 +14,15 @@ export default function UsersPage() {
 
   const [showAdd, setShowAdd] = useState(false);
   const [newUsername, setNewUsername] = useState('');
-  const [newPassword, setNewPassword] = useState('');
+  const [newEmail, setNewEmail] = useState('');
   const [newRole, setNewRole] = useState<UserRole>('user');
   const [createError, setCreateError] = useState('');
   const [creating, setCreating] = useState(false);
 
-  const [resetTarget, setResetTarget] = useState<ManagedUser | null>(null);
-  const [resetPassword, setResetPassword] = useState('');
-  const [resetError, setResetError] = useState('');
-  const [resetting, setResetting] = useState(false);
+  const [emailTarget, setEmailTarget] = useState<ManagedUser | null>(null);
+  const [emailValue, setEmailValue] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [savingEmail, setSavingEmail] = useState(false);
 
   const [deleteTarget, setDeleteTarget] = useState<ManagedUser | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -52,18 +52,18 @@ export default function UsersPage() {
 
   const handleCreate = async (e: FormEvent) => {
     e.preventDefault();
-    if (!newUsername.trim() || newPassword.length < 8) {
-      setCreateError('Username is required and password must be at least 8 characters.');
+    if (!newUsername.trim() || !newEmail.trim()) {
+      setCreateError('Username and Google email address are both required.');
       return;
     }
     setCreating(true);
     setCreateError('');
     try {
-      const created = await createUser({ username: newUsername.trim(), password: newPassword, role: newRole });
+      const created = await createUser({ username: newUsername.trim(), email: newEmail.trim(), role: newRole });
       setUsers(u => [...u, created]);
       setShowAdd(false);
       setNewUsername('');
-      setNewPassword('');
+      setNewEmail('');
       setNewRole('user');
       toast('success', 'User created.');
     } catch (err: any) {
@@ -83,24 +83,21 @@ export default function UsersPage() {
     }
   };
 
-  const handleResetPassword = async (e: FormEvent) => {
+  const handleSaveEmail = async (e: FormEvent) => {
     e.preventDefault();
-    if (!resetTarget) return;
-    if (resetPassword.length < 8) {
-      setResetError('Password must be at least 8 characters.');
-      return;
-    }
-    setResetting(true);
-    setResetError('');
+    if (!emailTarget) return;
+    setSavingEmail(true);
+    setEmailError('');
     try {
-      await updateUser(resetTarget.id, { password: resetPassword });
-      toast('success', `Password reset for ${resetTarget.username}.`);
-      setResetTarget(null);
-      setResetPassword('');
+      const updated = await updateUser(emailTarget.id, { email: emailValue.trim() });
+      setUsers(list => list.map(x => (x.id === updated.id ? updated : x)));
+      toast('success', `Sign-in email updated for ${emailTarget.username}.`);
+      setEmailTarget(null);
+      setEmailValue('');
     } catch (err: any) {
-      setResetError(err.response?.data?.error || 'Failed to reset password.');
+      setEmailError(err.response?.data?.error || 'Failed to update email.');
     } finally {
-      setResetting(false);
+      setSavingEmail(false);
     }
   };
 
@@ -152,6 +149,7 @@ export default function UsersPage() {
         <div className="user-list">
           <div className="user-row user-row--head">
             <span>Username</span>
+            <span>Google email</span>
             <span>Role</span>
             <span>Status</span>
             <span>Created</span>
@@ -162,6 +160,7 @@ export default function UsersPage() {
             return (
               <div key={u.id} className="user-row">
                 <span className="user-row__username">{u.username}</span>
+                <span className="user-row__email">{u.email || <em>not set — cannot sign in</em>}</span>
                 <span className="tag">{u.role}</span>
                 <span className={`status-badge status-badge--${u.is_active ? 'read' : 'unread'}`}>
                   {u.is_active ? 'Active' : 'Inactive'}
@@ -170,10 +169,10 @@ export default function UsersPage() {
                 <span className="user-row__actions">
                   <button
                     className="btn btn--secondary btn--sm btn--icon"
-                    title="Reset password"
-                    onClick={() => { setResetTarget(u); setResetPassword(''); setResetError(''); }}
+                    title="Change sign-in email"
+                    onClick={() => { setEmailTarget(u); setEmailValue(u.email || ''); setEmailError(''); }}
                   >
-                    <KeyRound size={14} />
+                    <Mail size={14} />
                   </button>
                   <button
                     className="btn btn--secondary btn--sm btn--icon"
@@ -213,15 +212,17 @@ export default function UsersPage() {
               />
             </div>
             <div className="form-group">
-              <label className="form-label" htmlFor="new-password">Password</label>
+              <label className="form-label" htmlFor="new-email">Google email</label>
               <input
-                id="new-password"
-                type="password"
+                id="new-email"
+                type="email"
                 className="form-input"
-                value={newPassword}
-                onChange={e => setNewPassword(e.target.value)}
-                autoComplete="new-password"
+                value={newEmail}
+                onChange={e => setNewEmail(e.target.value)}
+                autoComplete="off"
+                placeholder="reader@gmail.com"
               />
+              <p className="form-hint">Must match the Google account they sign in with.</p>
             </div>
             <div className="form-group">
               <label className="form-label" htmlFor="new-role">Role</label>
@@ -242,24 +243,25 @@ export default function UsersPage() {
         </Modal>
       )}
 
-      {resetTarget && (
-        <Modal title={`Reset password for ${resetTarget.username}`} onClose={() => setResetTarget(null)} size="sm">
-          <form onSubmit={handleResetPassword}>
-            {resetError && <p className="form-error">{resetError}</p>}
+      {emailTarget && (
+        <Modal title={`Sign-in email for ${emailTarget.username}`} onClose={() => setEmailTarget(null)} size="sm">
+          <form onSubmit={handleSaveEmail}>
+            {emailError && <p className="form-error">{emailError}</p>}
             <div className="form-group">
-              <label className="form-label" htmlFor="reset-password">New password</label>
+              <label className="form-label" htmlFor="edit-email">Google email</label>
               <input
-                id="reset-password"
-                type="password"
+                id="edit-email"
+                type="email"
                 className="form-input"
-                value={resetPassword}
-                onChange={e => setResetPassword(e.target.value)}
+                value={emailValue}
+                onChange={e => setEmailValue(e.target.value)}
                 autoFocus
-                autoComplete="new-password"
+                autoComplete="off"
               />
+              <p className="form-hint">Changing this signs them out everywhere.</p>
             </div>
-            <button type="submit" className="btn btn--primary" disabled={resetting} style={{ marginTop: 8 }}>
-              {resetting ? 'Resetting…' : 'Reset Password'}
+            <button type="submit" className="btn btn--primary" disabled={savingEmail} style={{ marginTop: 8 }}>
+              {savingEmail ? 'Saving…' : 'Save Email'}
             </button>
           </form>
         </Modal>

--- a/frontend/src/styles/_components.scss
+++ b/frontend/src/styles/_components.scss
@@ -124,6 +124,12 @@
   margin-top: $space-1;
 }
 
+.form-hint {
+  color: $text-3;
+  font-size: 0.75rem;
+  margin-top: $space-1;
+}
+
 // ── Library Controls (search + sort row) ──────────────────────────────────
 .library-controls {
   display: flex;
@@ -937,7 +943,7 @@
 
 .user-row {
   display: grid;
-  grid-template-columns: 1.5fr 0.8fr 0.9fr 1fr auto;
+  grid-template-columns: 1.2fr 1.6fr 0.7fr 0.8fr 0.9fr auto;
   align-items: center;
   gap: $space-3;
   padding: $space-3 $space-4;
@@ -965,6 +971,17 @@
     @include truncate;
   }
 
+  &__email {
+    font-size: 0.8125rem;
+    color: $text-2;
+    @include truncate;
+
+    em {
+      color: $text-3;
+      font-size: 0.75rem;
+    }
+  }
+
   &__date {
     font-size: 0.8125rem;
     color: $text-3;
@@ -976,7 +993,7 @@
     justify-content: flex-end;
   }
 
-  // Five grid columns (1.5fr 0.8fr 0.9fr 1fr auto) crush at phone widths.
+  // Six grid columns crush at phone widths.
   // Stack instead: username on its own line, role/status/date wrap together,
   // actions get their own full-width line.
   @media (max-width: $bp-md) {
@@ -989,6 +1006,10 @@
     &--head { display: none; }
 
     &__username {
+      flex: 1 0 100%;
+    }
+
+    &__email {
       flex: 1 0 100%;
     }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,12 +9,14 @@ export type MessageSourceType = 'book' | 'review' | 'wishlist' | 'text';
 export interface AuthUser {
   id: number;
   username: string;
+  email: string | null;
   role: UserRole;
 }
 
 export interface ManagedUser {
   id: number;
   username: string;
+  email: string | null;
   role: UserRole;
   is_active: number;
   created_at: string;

--- a/k8s/base/admin-secret.example.yaml
+++ b/k8s/base/admin-secret.example.yaml
@@ -2,11 +2,13 @@
 # with real values. Create the real secret out-of-band (or via SOPS):
 #
 #   kubectl -n vs-book-app create secret generic vs-book-app-admin \
-#     --from-literal=ADMIN_USERNAME=<username> \
-#     --from-literal=ADMIN_PASSWORD=<strong password>
+#     --from-literal=ADMIN_EMAIL=<your gmail address>
 #
-# The app seeds this admin only while the users table is empty; afterwards the
-# secret is inert and further user management happens in the app's admin UI.
+# On an empty database this seeds the first admin. On an existing database it
+# fills in the first admin's sign-in email if it is still NULL, which is the one
+# way into an app that predates OIDC. Either way it never overwrites an address
+# that is already set — after the first admin is in, everyone else is added from
+# the app's Users page.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,5 +16,4 @@ metadata:
   namespace: vs-book-app
 type: Opaque
 stringData:
-  ADMIN_USERNAME: change-me
-  ADMIN_PASSWORD: change-me
+  ADMIN_EMAIL: change-me@gmail.com

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -36,19 +36,32 @@ spec:
               value: http
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: deployment.environment.name=production,service.namespace=zakharhome
-            # Seeds the first admin only while the users table is empty;
-            # rotating these values later has no effect (use the in-app admin UI).
-            - name: ADMIN_USERNAME
+            # Public origin + base path. Google OIDC redirect_uri is derived from
+            # this as <APP_BASE_URL>/api/auth/callback and must match the value
+            # registered on the OAuth client exactly.
+            - name: APP_BASE_URL
+              value: https://books.zakharhome.org/books
+            # Sign-in returns 503 while these are unset.
+            - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: vs-book-app-admin
-                  key: ADMIN_USERNAME
+                  name: vs-book-app-oidc
+                  key: GOOGLE_CLIENT_ID
                   optional: true
-            - name: ADMIN_PASSWORD
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: vs-book-app-oidc
+                  key: GOOGLE_CLIENT_SECRET
+                  optional: true
+            # Seeds the first admin while the users table is empty, and otherwise
+            # backfills the first admin's email once (pre-OIDC databases). Never
+            # overwrites an address that is already set.
+            - name: ADMIN_EMAIL
               valueFrom:
                 secretKeyRef:
                   name: vs-book-app-admin
-                  key: ADMIN_PASSWORD
+                  key: ADMIN_EMAIL
                   optional: true
             - name: GITHUB_REPO
               value: mzakhar/vs-book-app

--- a/k8s/base/oidc-secret.example.yaml
+++ b/k8s/base/oidc-secret.example.yaml
@@ -1,0 +1,22 @@
+# Example only — NOT included in kustomization.yaml and must never be committed
+# with real values. Create the real secret out-of-band (or via SOPS):
+#
+#   kubectl -n vs-book-app create secret generic vs-book-app-oidc \
+#     --from-literal=GOOGLE_CLIENT_ID=<id>.apps.googleusercontent.com \
+#     --from-literal=GOOGLE_CLIENT_SECRET=<secret>
+#
+# From a "Web application" OAuth 2.0 Client ID in the Google Cloud console, with
+# this authorized redirect URI registered exactly:
+#
+#   https://books.zakharhome.org/books/api/auth/callback
+#
+# Sign-in returns 503 while either value is missing.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vs-book-app-oidc
+  namespace: vs-book-app
+type: Opaque
+stringData:
+  GOOGLE_CLIENT_ID: change-me.apps.googleusercontent.com
+  GOOGLE_CLIENT_SECRET: change-me


### PR DESCRIPTION
Passwords are gone. Identity comes from Google; authorization is a row in `users` with a matching `email`. An unrecognised Google account is rejected outright — no signup, no pending queue.

The session layer is untouched: the callback ends in the same `createSession`, the same `book_app_session` cookie, the same sliding 30-day renewal. Only the proof of identity changed.

## Backend

- **`oidc.ts`** — auth URL, PKCE, code exchange, `id_token` claim validation. No new dependencies: Google's endpoints are hardcoded (discovery is a round trip for values that haven't moved in a decade) and node's global `fetch` does the exchange.
- The `id_token` signature is deliberately **not** verified. The token arrives on our own TLS connection to Google's token endpoint in response to a code we minted — the case OIDC Core 3.1.3.7 exempts. The comment says so, and says never to extend it to browser-supplied tokens.
- `users.email` (unique index) is the allowlist key; `users.google_sub` is recorded on first sign-in. NULLs stay distinct, so pre-OIDC rows don't collide.
- `password_hash` survives as a dead `NOT NULL` column getting `''`. Dropping it means rebuilding a table six foreign keys point at — not worth it.
- `ADMIN_EMAIL` replaces `ADMIN_USERNAME`/`ADMIN_PASSWORD`: seeds the first admin on an empty DB, backfills the first admin's NULL email on an existing one, never overwrites a set address.
- Accounts registered under an email-shaped username get that address promoted into the allowlist automatically (two of the three live accounts).
- `POST /api/auth/dev-login`, gated on `DEV_LOGIN_EMAIL` and 404 in production, keeps local dev off Google — there's no HTTPS callback to offer it.
- Drops `bcryptjs`.

## Frontend

- Login page is one "Continue with Google" button plus a dev-only bypass; callback failures come back as `?error=<code>` and get turned into copy.
- Admin Users page manages sign-in emails instead of passwords. Changing one drops that user's sessions.

## Infra

- `k8s/base/oidc-secret.example.yaml` for `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`; `APP_BASE_URL` in the deployment drives the redirect URI and must byte-match the GCP client.
- GCP: project `vs-book-app`, consent screen "V's Books", External / In production, client `vs-book-app-web`. Scopes are `openid email` only — non-sensitive, so no verification and no user cap.

## Behaviour changes

| Before | After |
|---|---|
| LAN `http://192.168.1.3/books/` could log in | Broken — the `secure` state cookie dies over http. Sign in on the public host; LAN still works once authenticated |
| Deep link survived login | Always lands on `/books/` |
| Admin resets a password | Admin edits a sign-in email |

## Verification

`cd backend && npx ts-node src/oidc.check.ts` — covers auth-URL shape, PKCE base64url-ness, `id_token` decode, and eight claim-rejection cases (bad issuer, wrong audience, expired, unverified email, …). Both workspaces build.

## Deploy order

Cluster secrets (`vs-book-app-oidc`, `vs-book-app-admin` with `ADMIN_EMAIL`) must exist **before** the rollout, or sign-in returns 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)