### PR TITLE
fix(scan): don't decide whether to look up a scan inside a state updater

### DIFF
--- a/frontend/src/pages/ScanPage.tsx
+++ b/frontend/src/pages/ScanPage.tsx
@@ -57,6 +57,12 @@ export default function ScanPage() {
   const [manualEan, setManualEan] = useState<string | null>(null);
   // Books already owned, keyed by isbn — checked against on scan and updated after every save.
   const bookByIsbnRef = useRef<Map<string, Book>>(new Map());
+  // EANs already in the queue. This has to live outside React state: handleScan fires from
+  // the scanner's decode loop and must decide "new or repeat?" synchronously. Deciding it
+  // inside a setRows updater is unreliable — React invokes updaters eagerly only when the
+  // fiber has no pending work, so a scan arriving before the previous render committed
+  // would skip its lookup and hang on "Looking up…" forever.
+  const queuedEansRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     getBooks().then(books => {
@@ -79,24 +85,25 @@ export default function ScanPage() {
   const handleScan = (raw: string) => {
     const ean = normalizeIsbn(raw);
     if (!ean) return;
-    let added = false;
-    setRows(prev => {
-      if (prev.some(r => r.ean === ean)) return prev;
-      added = true;
-      const duplicateOf = bookByIsbnRef.current.get(ean);
-      return [...prev, {
-        ean,
-        state: 'looking-up',
-        status: 'unread',
-        include: !duplicateOf,
-        saveState: 'idle',
-        duplicateOf,
-      }];
-    });
-    if (added) resolveRow(ean);
+    if (queuedEansRef.current.has(ean)) return;
+    queuedEansRef.current.add(ean);
+
+    const duplicateOf = bookByIsbnRef.current.get(ean);
+    setRows(prev => [...prev, {
+      ean,
+      state: 'looking-up',
+      status: 'unread',
+      include: !duplicateOf,
+      saveState: 'idle',
+      duplicateOf,
+    }]);
+    resolveRow(ean);
   };
 
-  const removeRow = (ean: string) => setRows(prev => prev.filter(r => r.ean !== ean));
+  const removeRow = (ean: string) => {
+    queuedEansRef.current.delete(ean);
+    setRows(prev => prev.filter(r => r.ean !== ean));
+  };
 
   const setRowStatus = (ean: string, status: BookStatus) =>
     setRows(prev => prev.map(r => r.ean === ean ? { ...r, status } : r));
@@ -118,6 +125,7 @@ export default function ScanPage() {
       try {
         const book = await createBook(toPayload(row));
         bookByIsbnRef.current.set(row.ean, book);
+        queuedEansRef.current.delete(row.ean);
         savedCount++;
         setRows(prev => prev.filter(r => r.ean !== row.ean));
       } catch (err: any) {


### PR DESCRIPTION
handleScan set a local `added` flag from inside the setRows updater and read
it back on the next line to decide whether to fire the lookup. React invokes
updaters eagerly only when the fiber has no pending work; with an update
already queued it just enqueues, so `added` was still false and resolveRow
was never called. The row then sat at state:'looking-up' forever, because
nothing else ever writes it — both lookup functions swallow their errors and
return null, which yields 'unresolved' rather than a hang.

Scanning a stack makes this constant: every completed lookup fires its own
setRows a few hundred ms later, so there is nearly always an update in flight
for the next scan to collide with. Roughly every other book hung.

Track queued EANs in a ref instead, so the new-vs-repeat decision is
synchronous and independent of React's scheduling. The ref is cleared
wherever a row leaves the queue (manual remove, successful save) so a book
can be rescanned afterwards.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018FpFJeqmejAZFNhwToq5dd
